### PR TITLE
Removed bad default-server statement from nginx config

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/base-nginx.conf.erb
+++ b/chef/cookbooks/provisioner/templates/default/base-nginx.conf.erb
@@ -15,7 +15,7 @@ http {
      types_hash_max_size 8192;
 
      server {
-     	    listen <%=@port%> default_server;
+     	    listen <%=@port%>;
 	    root <%=@docroot%>;
 	    autoindex on;
      }


### PR DESCRIPTION
The default-server bit in the listen line was causing nginx to fail upon restart and admin node rebooting. This meant you couldn't provision new nodes.
