### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [11/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -73,6 +73,10 @@
   "deployment": {
     "provisioner": {
       "crowbar-revision": 0,
+      "element_states": {
+        "provisioner-server": [ "readying", "ready", "applying" ],
+        "provisioner-base": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [ "provisioner-server" ], 

--- a/chef/data_bags/crowbar/bc-template-provisioner.schema
+++ b/chef/data_bags/crowbar/bc-template-provisioner.schema
@@ -67,6 +67,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 .../data_bags/crowbar/bc-template-provisioner.json |    4 ++++
 .../crowbar/bc-template-provisioner.schema         |   10 ++++++++++
 2 files changed, 14 insertions(+), 0 deletions(-)
