### PR TITLE
Many defects and IPMI/BIOS/Network work [3/8]

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -30,7 +30,7 @@ if not nodes.nil? and not nodes.empty?
 
     # Delete the node
     system("knife node delete -y #{mnode.name} -u chef-webui -k /etc/chef/webui.pem") if new_group == "delete"
-    system("knife node delete -y crowbar-#{mnode.name.gsub(".","_")} -u chef-webui -k /etc/chef/webui.pem") if new_group == "delete"
+    system("knife role delete -y crowbar-#{mnode.name.gsub(".","_")} -u chef-webui -k /etc/chef/webui.pem") if new_group == "delete"
 
     admin_data_net = Chef::Recipe::Barclamp::Inventory.get_network_by_type(mnode, "admin")
 

--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -64,7 +64,8 @@
           "update": "update",
           "ready": "execute",
           "reset": "reset",
-          "delete": "delete",
+          "delete": "noop",
+          "delete-final": "delete",
           "reinstall": "os_install"
         }
       }

--- a/crowbar_framework/app/models/provisioner_service.rb
+++ b/crowbar_framework/app/models/provisioner_service.rb
@@ -88,6 +88,13 @@ class ProvisionerService < ServiceObject
       end
     end
 
+    if state == "delete"
+      # BA LOCK NOT NEEDED HERE.  NODE IS DELETING
+      node = NodeObject.find_node_by_name(name)
+      node.crowbar["state"] = "delete-final"
+      node.save
+    end
+
     #
     # test state machine and call chef-client if state changes
     #


### PR DESCRIPTION
```
BIOS/IPMI/NETWORK updates

IPMI Changes:
* Don't use crowbar user for now.  Use root until iDRAC and PEC issues are resolved
* Add setting dedicated mode for PER to ipmi code path
* Add discover role to get ipmi settings and write them on the wall (DE193)

Deployer Changes:
* Use the ipmi wall settings to suggest to the network barclamp (no toggle) (DE193)

Network Changes:
* Allocate IP can take a suggestion for the IP to allocate (DE193)
* Added deallocate_ip and disable_interface as REST API routines (DE175)
* Update the network barclamp to watch for delete and remove nodes (DE175)

Provisioner Changes:
* Add temp state delete-final that allows for bc's to search before actual delete
  (DE669 and DE667)
* Fix latent delete bug that wasn't deleting the node role.

DE672 was reviewed and already implemented.
```

 chef/cookbooks/provisioner/recipes/update_nodes.rb |    2 +-
 .../data_bags/crowbar/bc-template-provisioner.json |    3 ++-
 .../app/models/provisioner_service.rb              |    7 +++++++
 3 files changed, 10 insertions(+), 2 deletions(-)
