### PR TITLE
Update Crowbar to generate Centos 6.2 sledgehammer images. [2/6]

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/compute.ks.erb
+++ b/chef/cookbooks/provisioner/templates/default/compute.ks.erb
@@ -57,6 +57,7 @@ emacs-nox
 openssh
 curl.x86_64
 ntp
+tcpdump
 
 %post
 

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.ubuntu.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.ubuntu.sh.erb
@@ -106,7 +106,8 @@ if [[ ! -x /etc/init.d/bluepill ]]; then
         sleep 1
     done
     log_to apt /usr/bin/debconf-set-selections /tmp/debsel.conf
-    while ! log_to apt /usr/bin/apt-get --force-yes -y install chef libxml2-dev zlib1g-dev ; do
+    while ! log_to apt /usr/bin/apt-get --force-yes -y install \
+        chef libxml2-dev zlib1g-dev tcpdump; do
         echo "Failed to apt-get install, wait and try again"
         sleep 1
     done


### PR DESCRIPTION
This pull request series does the following:
- Fold the bulk of the Sledgehammer repo back into the main Crowbar
  repository.
- While we are at it, update the Sledgehammer build to stage
  everything on CentOS 6.2
- Tear out the custom-compiled tcpdump we were using, the one in
  CentOS 6 works just fine.
