### PR TITLE
Fix console-setup issue preventing the node from being "ready"

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.ubuntu.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.ubuntu.sh.erb
@@ -25,6 +25,7 @@ esac
 exec 2>>/var/log/crowbar-join.errlog
 
 export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
+export DEBIAN_FRONTEND=noninteractive
 set -x
 
 if [[ -f /etc/crowbar.install.key ]]; then


### PR DESCRIPTION
hi, DEBIAN_FRONTEND=noninteractive should be used for any scripts to suppress user input awaiting
