### PR TITLE
Pull changes from development into essex-hack [9/16]

### DIFF
--- a/chef/cookbooks/dhcp/recipes/default.rb
+++ b/chef/cookbooks/dhcp/recipes/default.rb
@@ -108,7 +108,7 @@ when "ubuntu","debian"
 when "redhat","centos"
 
   dhcp_config_file = case
-    when node[:platform] == "redhat" && node[:platform_version].to_f >= 6
+    when node[:platform_version].to_f >= 6
       "/etc/dhcp/dhcpd.conf"
     else
       "/etc/dhcpd.conf"

--- a/chef/cookbooks/nfs-server/recipes/default.rb
+++ b/chef/cookbooks/nfs-server/recipes/default.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+rpcService="portmap"
 case node[:platform]
 when "ubuntu","debian"
   package "nfs-common"
@@ -35,14 +36,10 @@ when "ubuntu","debian"
 
 when "centos","redhat"
   package "nfs-utils"
-end
-
-rpcService = case
-  when node[:platform] == "redhat" && node[:platform_version].to_f >= 6
-    "rpcbind"
-  else
-    "portmap"
+  if node[:platform_version].to_f >= 6
+    rpcService="rpcbind"
   end
+end
 
 package rpcService
 
@@ -80,4 +77,3 @@ template "/etc/exports" do
             :admin_netmask => node["network"]["networks"]["admin"]["netmask"])
   notifies :run, "execute[nfs-export]", :delayed
 end
-

--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -22,7 +22,7 @@ domain_name = node[:dns].nil? ? node[:domain] : (node[:dns][:domain] || node[:do
 web_port = node[:provisioner][:web_port]
 use_local_security = node[:provisioner][:use_local_security]
 provisioner_web="http://#{admin_ip}:#{web_port}"
-append_line = "append root=/sledgehammer.iso rootfstype=iso9660 rootflags=loop"
+append_line = ''
 os_token="#{node[:platform]}-#{node[:platform_version]}"
 
 tftproot = node[:provisioner][:root]
@@ -30,16 +30,28 @@ tftproot = node[:provisioner][:root]
 if node[:provisioner][:use_serial_console]
   append_line += " console=tty0 console=ttyS1,115200n8"
 end
-if ::File.exists?("/etc/crowbar.install.key")
-  append_line += " crowbar.install.key=#{::File.read("/etc/crowbar.install.key").chomp.strip}"
-end
 
 pxecfg_dir="#{tftproot}/discovery/pxelinux.cfg"
+pxecfg_default="#{tftproot}/discovery/pxelinux.cfg/default"
 
 bash "Install pxelinux.0" do
   code "cp /usr/lib/syslinux/pxelinux.0 #{tftproot}/discovery"
   not_if do ::File.exists?("#{tftproot}/discovery/pxelinux.0") end
 end
+
+if File.exists? pxecfg_default
+  append_line = IO.readlines(pxecfg_default).detect{|l| /APPEND/i =~ l}
+  if append_line
+    append_line = append_line.strip.gsub(/(^APPEND |initrd=[^ ]+|rhgb|quiet|crowbar\.[^ ]+)/i,'')
+  else
+    append_line = "root=/sledgehammer.iso rootfstype=iso9660 rootflags=loop"
+  end
+end
+
+if ::File.exists?("/etc/crowbar.install.key")
+  append_line += " crowbar.install.key=#{::File.read("/etc/crowbar.install.key").chomp.strip}"
+end
+
 
 # Generate the appropriate pxe config file for each state
 [ "discovery","update","hwinstall"].each do |state|
@@ -221,15 +233,18 @@ node[:provisioner][:supported_oses].each do |os,params|
                 :admin_web => admin_web,
                 :crowbar_join => "#{web_path}/crowbar_join.sh")  
     end
-      
     template "#{os_dir}/crowbar_join.sh" do
       mode 0644
       owner "root"
       group "root"
       source "crowbar_join.redhat.sh.erb"
-      variables(:admin_ip => admin_ip)
+      variables(:admin_web => admin_web,
+                :os_codename => os_codename,
+                :crowbar_repo_web => crowbar_repo_web,
+                :admin_ip => admin_ip,
+                :provisioner_web => provisioner_web,
+                :web_path => web_path)
     end
-    
 
   when /^ubuntu/ =~ os
     node[:provisioner][:repositories][os_token]["base"] = "http://#{admin_ip}:#{web_port}/#{os_token}/install"
@@ -264,7 +279,7 @@ node[:provisioner][:supported_oses].each do |os,params|
       group "root"
       source "net-pre-install.sh"
     end
-
+    
     template "#{os_dir}/crowbar_join.sh" do
       mode 0644
       owner "root"

--- a/chef/cookbooks/provisioner/templates/default/compute.ks.erb
+++ b/chef/cookbooks/provisioner/templates/default/compute.ks.erb
@@ -57,6 +57,7 @@ emacs-nox
 openssh
 curl.x86_64
 ntp
+tcpdump
 
 %post
 

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.redhat.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.redhat.sh.erb
@@ -19,11 +19,8 @@ case $1 in
     status) service chef-client status ; exit $? ;;
     start|'') pidof chef-client && exit 0;;
     *) echo "Unknown action to crowbar_join.sh."
-	exit 1;;
+        exit 1;;
 esac
-
-HTTP_SERVER="<%= @admin_ip %>:8091"
-IP=${HTTP_SERVER%:*}
 
 exec 2>>/var/log/crowbar-join.errlog
 
@@ -42,17 +39,17 @@ log_to() {
     local __timestamp="$(date '+%F %T %z')"
     shift
     printf "\n%s\n" "$__timestamp: Running $*" | \
-	tee -a "$__log.err" >> "$__log.log"
+        tee -a "$__log.err" >> "$__log.log"
     local _ret=0
     if "$@" 2>> "$__log.err" >>"$__log.log"; then
-	_ret=0
+        _ret=0
     else
-	_ret="$?"
-	echo "$__timestamp: $* failed."
-	echo "See $__log.log and $__log.err for more information."
+        _ret="$?"
+        echo "$__timestamp: $* failed."
+        echo "See $__log.log and $__log.err for more information."
     fi
     printf "\n$s\n--------\n"  "$(date '+%F %T %z'): Done $*" | \
-	tee -a "$__log.err" >> "$__log.log"
+        tee -a "$__log.err" >> "$__log.log"
     return $_ret
 }
 
@@ -62,7 +59,7 @@ post_state() {
       -H "Accept: application/json" -H "Content-Type: application/json" \
       --max-time 240)
   [[ $CROWBAR_KEY ]] && curlargs+=(-u "$CROWBAR_KEY" --digest --anyauth)
-  curl "${curlargs[@]}" "http://$IP:3000/crowbar/crowbar/1.0/transition/default"
+  curl "${curlargs[@]}" "http://<%=@admin_ip%>:3000/crowbar/crowbar/1.0/transition/default"
 }
 
 # Make sure we never install 32 bit packages.
@@ -84,9 +81,9 @@ sync_time() {
     # stop ntpd before we run ntpdate, and start it again afterwards.
     service ntp stop
     killall ntpd
-    while ! /usr/sbin/ntpdate -b $IP; do
-	echo "Waiting for NTP server"
-	sleep 1
+    while ! /usr/sbin/ntpdate -b <%=@admin_ip%>; do
+        echo "Waiting for NTP server"
+        sleep 1
     done
 }
 
@@ -94,8 +91,8 @@ sync_time() {
 # delays.
 if ! grep -q '^UseDNS.*no' /etc/ssh/sshd_config; then
     sed -i -e 's/^\(GSSAPI\)/#\1/' \
-	-e 's/#\(UseDNS.*\)yes/\1no/' \
-	/etc/ssh/sshd_config
+        -e 's/#\(UseDNS.*\)yes/\1no/' \
+        /etc/ssh/sshd_config
     service sshd restart
 fi
 
@@ -103,59 +100,55 @@ fi
 rm -f /update_system2.sh
 rm -f /net-post-install.sh
 
-echo "Synchronizing time (pass 1)" 
+echo "Synchronizing time (pass 1)"
 sync_time
 
 # Mark us as readying, and get our cert.
 post_state $HOSTNAME "readying"
 final_state="ready"
 mkdir -p /etc/chef
-curl -o /etc/chef/validation.pem \
-    "http://$HTTP_SERVER/validation.pem"
+curl -o /etc/chef/validation.pem "<%=@provisioner_web%>/validation.pem"
 
-if [[ ! -x /etc/init.d/bluepill ]]; then 
+if [[ ! -x /etc/init.d/bluepill ]]; then
     # Make sure that the client knows how to talk to the server
-    echo "chef_server_url \"http://$IP:4000\"" >/etc/chef/client.rb
+    echo "chef_server_url \"http://<%=@admin_ip%>:4000\"" >/etc/chef/client.rb
 
     # Install Chef
     echo "Installing Chef..."
 
     while ! log_to yum yum -q -y update ; do
-	echo "Failed to do yum update, wait and try again"
-	sleep 1
+        echo "Failed to do yum update, wait and try again"
+        sleep 1
     done
     while ! log_to yum yum -q -y install rubygem-chef patch libxml2-devel zlib-devel ; do
-	echo "Failed to do yum install, wait and try again"
-	sleep 1
+        echo "Failed to do yum install, wait and try again"
+        sleep 1
     done
-
-    # Install ohai patch if needed.
-    di=$(find /usr -path '*/ohai-0.6.6/lib/ohai/plugins/linux' -type d)
-    [[ $di && -d $di ]] && {
-	curl -o "$di/ohai.patch" \
-	    "http://$HTTP_SERVER/redhat_dvd/extra/patches/ohai-linux-platform.patch"
-	[[ -f $di/ohai.patch ]] && (
-	    cd "$di"
-	    patch -p0 <ohai.patch
-	)
-    }
-
     log_to chef service chef-client stop
     log_to chef killall chef-client
     log_to chef chkconfig chef-client off
     chmod 644 /etc/init.d/chef-client
 
+    # Install Chef patches Crowbar needs.
+    mkdir -p /opt/dell/
+    (   cd /opt/dell
+        wget -q "<%=@provisioner_web%>/patches.tar.gz"
+        tar xzvf patches.tar.gz
+        cd patches
+        ./patch.sh
+    )
+
     # Make rubygems do what we want.
     cat >/etc/gemrc <<EOF
 :sources:
-- http://$HTTP_SERVER/gemsite/
+- <%=@provisioner_web%>/gemsite/
 gem: --no-ri --no-rdoc --bindir /usr/local/bin
 EOF
     gem install xml-simple
     gem install libxml-ruby
     gem install bluepill
     mkdir -p /etc/bluepill
-    curl -o /etc/bluepill/chef-client.pill http://$HTTP_SERVER/chef-client.pill
+    curl -o /etc/bluepill/chef-client.pill <%=@provisioner_web%>/chef-client.pill
     # Create an init script for bluepill
     cat > /etc/init.d/bluepill <<EOF
 #!/bin/bash
@@ -177,7 +170,7 @@ case \$1 in
              exit 1
             fi;;
     *) echo "\$1: Not supported.";;
-esac   
+esac
 EOF
     chmod 755 /etc/init.d/bluepill
 fi
@@ -209,7 +202,7 @@ if ! log_to chef chef-client -l debug; then
     echo "Removing Chef Cache"
     rm -rf /var/cache/chef/*
     echo "Running Chef Client (pass 3) - cache cleanup"
-    if ! log_to chef chef-client -l debug; then 
+    if ! log_to chef chef-client -l debug; then
         log_to ifup /sbin/service network restart
         echo "Error Path"
         echo "Syncing Time (pass 4)"
@@ -220,7 +213,7 @@ if ! log_to chef chef-client -l debug; then
         rm -f /etc/chef/client.pem
         post_state $HOSTNAME "hardware-updated"
         echo "Running Chef Client (pass 4) - password cleanup"
-        if ! log_to chef chef-client -l debug; then 
+        if ! log_to chef chef-client -l debug; then
             log_to ifup /sbin/service network restart
             echo "chef-client run failed four times, giving up."
             echo "Failed"

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.ubuntu.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.ubuntu.sh.erb
@@ -19,7 +19,7 @@ case $1 in
     status) bluepill chef-client status ; exit $? ;;
     start|'') : ;;
     *) echo "Unknown action to crowbar_join.sh."
-	exit 1;;
+        exit 1;;
 esac
 
 exec 2>>/var/log/crowbar-join.errlog
@@ -40,17 +40,17 @@ log_to() {
     local __timestamp="$(date '+%F %T %z')"
     shift
     printf "\n%s\n" "$__timestamp: Running $*" | \
-	tee -a "$__log.err" >> "$__log.log"
+        tee -a "$__log.err" >> "$__log.log"
     local _ret=0
     if "$@" 2>> "$__log.err" >>"$__log.log"; then
-	_ret=0
+        _ret=0
     else
-	_ret="$?"
-	echo "$__timestamp: $* failed."
-	echo "See $__log.log and $__log.err for more information."
+        _ret="$?"
+        echo "$__timestamp: $* failed."
+        echo "See $__log.log and $__log.err for more information."
     fi
     printf "\n$s\n--------\n"  "$(date '+%F %T %z'): Done $*" | \
-	tee -a "$__log.err" >> "$__log.log"
+        tee -a "$__log.err" >> "$__log.log"
     return $_ret
 }
 
@@ -79,8 +79,8 @@ sync_time() {
     service ntp stop
     killall ntpd
     while ! /usr/sbin/ntpdate -b <%=@admin_ip%>; do
-	echo "Waiting for NTP server"
-	sleep 1
+        echo "Waiting for NTP server"
+        sleep 1
     done
 }
 
@@ -88,7 +88,7 @@ sync_time() {
 rm -f /update_system2.sh
 rm -f /net-post-install.sh
 
-echo "Synchronizing time (pass 1)" 
+echo "Synchronizing time (pass 1)"
 sync_time
 
 # Mark us as readying, and get our cert.
@@ -103,13 +103,14 @@ if [[ ! -x /etc/init.d/bluepill ]]; then
     echo "chef chef/chef_server_url string http://<%=@admin_ip%>:4000" >/tmp/debsel.conf
 
     while ! log_to apt /usr/bin/apt-get update ; do
-	echo "Failed to apt-get update, wait and try again"
-	sleep 1
+        echo "Failed to apt-get update, wait and try again"
+        sleep 1
     done
     log_to apt /usr/bin/debconf-set-selections /tmp/debsel.conf
-    while ! log_to apt /usr/bin/apt-get --force-yes -y install chef libxml2-dev zlib1g-dev ; do
-	echo "Failed to apt-get install, wait and try again"
-	sleep 1
+    while ! log_to apt /usr/bin/apt-get --force-yes -y install \
+        chef libxml2-dev zlib1g-dev tcpdump; do
+        echo "Failed to apt-get install, wait and try again"
+        sleep 1
     done
 
     # Disable the chef-client service and make it not executable.
@@ -118,9 +119,13 @@ if [[ ! -x /etc/init.d/bluepill ]]; then
     log_to chef update-rc.d chef-client disable
     log_to chef chmod ugo-x /etc/init.d/chef-client
 
-    # Pull in patches
-    curl -o /usr/lib/ruby/1.8/ohai/mixin/command.rb <%=@provisioner_web%>/patches/command.rb
-    curl -o /usr/lib/ruby/vendor_ruby/chef/mixin/command/unix.rb <%=@provisioner_web%>/patches/unix.rb
+    mkdir -p /opt/dell/
+    (   cd /opt/dell
+        wget -q "<%=@provisioner_web%>/patches.tar.gz"
+        tar xzvf patches.tar.gz
+        cd patches
+        ./patch.sh
+    )
 
     # Make rubygems do what we want.
     cat >/etc/gemrc <<EOF
@@ -154,12 +159,12 @@ case \$1 in
              exit 1
             fi;;
     *) echo "\$1: Not supported.";;
-esac   
+esac
 EOF
     chmod 755 /etc/init.d/bluepill
 fi
 
-    
+
 # Run Chef
 echo "Syncing time (pass 2)"
 sync_time
@@ -169,7 +174,7 @@ sync_time
 # the networking barclamp changing the IP address from dhcp to static.
 # We will try to pick up and run with it.
 echo "Running Chef Client  (pass 1)"
-log_to chef chef-client 
+log_to chef chef-client
 
 # Make sure our interfaces are as up as we can get them
 echo "Ensuring that our network interfaces are up."
@@ -178,7 +183,7 @@ log_to ifup ifup -a
 # Only transition to problem state if the second run fails.
 echo "Running Chef Client (pass 2)"
 if ! log_to chef chef-client ; then
-    log_to ifup ifup -a 
+    log_to ifup ifup -a
     post_state $HOSTNAME "recovering"
     echo "Error Path"
     echo "Syncing Time (pass 3)"
@@ -188,8 +193,8 @@ if ! log_to chef chef-client ; then
     echo "Checking Install Integrity"
     log_to apt /usr/bin/apt-get -q --force-yes -y install
     echo "Running Chef Client (pass 3) - apt/cache cleanup"
-    if ! log_to chef chef-client ; then 
-        log_to ifup ifup -a 
+    if ! log_to chef chef-client ; then
+        log_to ifup ifup -a
         echo "Error Path"
         echo "Syncing Time (pass 4)"
         sync_time
@@ -201,7 +206,7 @@ if ! log_to chef chef-client ; then
         rm -f /etc/chef/client.pem
         post_state $HOSTNAME "hardware-updated"
         echo "Running Chef Client (pass 4) - password cleanup"
-        if ! log_to chef chef-client ; then 
+        if ! log_to chef chef-client ; then
             log_to ifup ifup -a
             echo "chef-client run failed four times, giving up."
             echo "Failed"

--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -69,7 +69,8 @@
           "update": "update",
           "ready": "execute",
           "reset": "reset",
-          "delete": "delete",
+          "delete": "noop",
+          "delete-final": "delete",
           "reinstall": "os_install"
         }
       }

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -108,6 +108,7 @@ rpms:
       - tar
   pkgs:
     - dhcp
+    - dhclient
     - nfs-utils
     - syslinux
     - tftp-server

--- a/crowbar_framework/app/models/provisioner_service.rb
+++ b/crowbar_framework/app/models/provisioner_service.rb
@@ -88,6 +88,13 @@ class ProvisionerService < ServiceObject
       end
     end
 
+    if state == "delete"
+      # BA LOCK NOT NEEDED HERE.  NODE IS DELETING
+      node = NodeObject.find_node_by_name(name)
+      node.crowbar["state"] = "delete-final"
+      node.save
+    end
+
     #
     # test state machine and call chef-client if state changes
     #

--- a/updates/control.sh
+++ b/updates/control.sh
@@ -39,8 +39,12 @@ cd -
 
 # Add full code set
 if [ -e /updates/full_data.sh ] ; then
-  /updates/full_data.sh
+  cp /updates/full_data.sh /tmp
+  /tmp/full_data.sh
 fi
+
+# Get stuff out of nfs.
+cp /updates/parse_node_data /tmp
 
 # get validation cert
 curl -L -o /etc/chef/validation.pem \
@@ -48,7 +52,7 @@ curl -L -o /etc/chef/validation.pem \
     "http://$ADMIN_IP:8091/validation.pem"
 
 parse_node_data() {
-  for s in $(/updates/parse_node_data -a name -a crowbar.network.bmc.netmask -a crowbar.network.bmc.address -a crowbar.network.bmc.router -a crowbar.allocated $1) ; do
+  for s in $(/tmp/parse_node_data -a name -a crowbar.network.bmc.netmask -a crowbar.network.bmc.address -a crowbar.network.bmc.router -a crowbar.allocated $1) ; do
     VAL=${s#*=}
     case ${s%%=*} in
       name) export HOSTNAME=$VAL;;
@@ -89,15 +93,15 @@ get_state() {
 nuke_everything() {
     # Make sure that the kernel knows about all the partitions
     for bd in /sys/block/sd*; do
-	[[ -b /dev/${bd##*/} ]] || continue
-	partprobe "/dev/${bd##*/}"
+        [[ -b /dev/${bd##*/} ]] || continue
+        partprobe "/dev/${bd##*/}"
     done
     # and then wipe them all out.
     while read maj min blocks name; do
-	[[ -b /dev/$name && -w /dev/$name && $name != name ]] || continue
-	[[ $name = loop* ]] && continue
-	[[ $name = dm* ]] && continue
-	if (( blocks >= 2048)); then
+        [[ -b /dev/$name && -w /dev/$name && $name != name ]] || continue
+        [[ $name = loop* ]] && continue
+        [[ $name = dm* ]] && continue
+        if (( blocks >= 2048)); then
             dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=2048"
             dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=2048" "seek=$(($blocks - 2048))"
         else
@@ -114,7 +118,7 @@ run_chef () {
 
 case $STATE in
     discovery)  
-	echo "Discovering with: $HOSTNAME_MAC"
+        echo "Discovering with: $HOSTNAME_MAC"
         post_state $HOSTNAME_MAC discovering
         run_chef $HOSTNAME_MAC
         post_state $HOSTNAME_MAC discovered
@@ -136,16 +140,16 @@ case $STATE in
         post_state $HOSTNAME hardware-installing
         nuke_everything
         run_chef $HOSTNAME
-	if [ -a /var/log/chef/hw-problem.log ]; then
-	  post_state $HOSTNAME problem
-	else 	 
+        if [ -a /var/log/chef/hw-problem.log ]; then
+          post_state $HOSTNAME problem
+        else          
           post_state $HOSTNAME hardware-installed
-	fi
-	nuke_everything
+        fi
+        nuke_everything
         sleep 30 # Allow settle time
         maybe_reboot;;
     hwinstall)  
-	while [ "$NODE_STATE" != "true" ] ; do
+        while [ "$NODE_STATE" != "true" ] ; do
             sleep 15
             get_state
         done
@@ -154,22 +158,22 @@ case $STATE in
         nuke_everything
         echo "Hardware installing with: $HOSTNAME"
         run_chef $HOSTNAME
-	if [ -a /var/log/chef/hw-problem.log ]; then
-	    post_state $HOSTNAME problem
-	else 	 
-	    post_state $HOSTNAME hardware-installed
-	fi
-	nuke_everything
+        if [ -a /var/log/chef/hw-problem.log ]; then
+            post_state $HOSTNAME problem
+        else          
+            post_state $HOSTNAME hardware-installed
+        fi
+        nuke_everything
         sleep 30 # Allow settle time
         maybe_reboot;;
     update)  
-	post_state $HOSTNAME hardware-updating
+        post_state $HOSTNAME hardware-updating
         run_chef $HOSTNAME
-	if [ -a /var/log/chef/hw-problem.log ]; then
-	    post_state $HOSTNAME problem
-	else 	 
+        if [ -a /var/log/chef/hw-problem.log ]; then
+            post_state $HOSTNAME problem
+        else          
             post_state $HOSTNAME hardware-updated
-	fi
+        fi
         sleep 30 # Allow settle time
         maybe_reboot;;
 esac 2>&1 | tee -a /install-logs/$HOSTNAME-update.log


### PR DESCRIPTION
Synchronize essex-hack with development. Among other things, this
pulls in:
- Numerous UI improvements.
- Enhancements and bugfixes galore in the dev tool and build system.
- Sledgehammer on CentOS 6.2 support.
- Somewhat more standardized patch management for our Chef and Rails
  patches.

This pull request series has been smoketested on virtual machines, and
is able to spin up vms in Nova using the dashboard.

 chef/cookbooks/dhcp/recipes/default.rb             |    2 +-
 chef/cookbooks/nfs-server/recipes/default.rb       |   12 +--
 .../provisioner/recipes/setup_base_images.rb       |   31 ++++++--
 chef/cookbooks/provisioner/recipes/update_nodes.rb |   14 ++--
 .../provisioner/templates/default/compute.ks.erb   |    1 +
 .../templates/default/crowbar_join.redhat.sh.erb   |   77 +++++++++-----------
 .../templates/default/crowbar_join.ubuntu.sh.erb   |   55 ++++++++-------
 .../data_bags/crowbar/bc-template-provisioner.json |    3 +-
 crowbar.yml                                        |    1 +
 .../app/models/provisioner_service.rb              |    7 ++
 updates/control.sh                                 |   56 ++++++++-------
 11 files changed, 141 insertions(+), 118 deletions(-)
