### PR TITLE
Make sure sledgehammer syncs and umounts filesystems before shutting down. [2/6]

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -115,9 +115,7 @@ nuke_everything() {
             dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=$blocks"
         fi
     done < <(tac /proc/partitions)
-} 
-
-maybe_reboot () { [[ $DEBUG != 1 ]] && reboot; }
+}
 
 run_chef () {
   chef-client -S http://$ADMIN_IP:4000/ -N $1
@@ -145,9 +143,7 @@ case $STATE in
         else          
           post_state $HOSTNAME hardware-installed
         fi
-        nuke_everything
-        sleep 30 # Allow settle time
-        maybe_reboot;;
+        nuke_everything;;
     hwinstall)  
         while [ "$NODE_STATE" != "true" ] ; do
             sleep 15
@@ -163,9 +159,7 @@ case $STATE in
         else          
             post_state $HOSTNAME hardware-installed
         fi
-        nuke_everything
-        sleep 30 # Allow settle time
-        maybe_reboot;;
+        nuke_everything;;
     update)  
         post_state $HOSTNAME hardware-updating
         run_chef $HOSTNAME
@@ -173,7 +167,11 @@ case $STATE in
             post_state $HOSTNAME problem
         else          
             post_state $HOSTNAME hardware-updated
-        fi
-        sleep 30 # Allow settle time
-        maybe_reboot;;
+        fi;;
 esac 2>&1 | tee -a /install-logs/$HOSTNAME-update.log
+if [[ $DEBUG != 1 && $DEBUG != true ]]; then
+    sync
+    sleep 30
+    umount /updates /install-logs
+    reboot
+fi


### PR DESCRIPTION
This should help keep us from losing the logs from Sledgehammer.

Along the way, fix up a bug that was trying to assign a default route to 
the BMC even though bmc_router was the empty string, and add a couple of useful
options to the test framework for running in mixed virtual and physical
environments.

 updates/control.sh |   22 ++++++++++------------
 1 file changed, 10 insertions(+), 12 deletions(-)
