### PR TITLE
Add support for debian source repositories, and pull in the MySQL source code. [1/7]

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/compute.ks.erb
+++ b/chef/cookbooks/provisioner/templates/default/compute.ks.erb
@@ -65,11 +65,13 @@ exec > /root/post-install.log 2>&1
 set -x
 export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
 (cd /etc/yum.repos.d && rm *)
-<% @repos.each do |repo,url| -%>
+<% @repos.keys.sort.each do |repo| -%>
 cat >/etc/yum.repos.d/crowbar-<%=repo%>.repo <<EOF
 [crowbar-<%=repo%>]
 name=Crowbar <%=repo%> Repo
-<%=url%>
+<% @repos[repo].keys.sort.each do |url| -%>
+<%= url %>
+<% end -%>
 gpgcheck=0
 EOF
 <% end %>

--- a/chef/cookbooks/provisioner/templates/default/net-post-install.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/net-post-install.sh.erb
@@ -27,16 +27,18 @@
 # We are a net install. 
 #
 
-<% @repos.each do |repo,url| -%>
-<% case repo -%>
-<% when "base" -%>
+<% @repos.keys.sort.each do |repo|
+     @repos[repo].keys.sort.each do |url|
+       case repo 
+       when "base" -%>
 echo "deb <%=url%> <%= @os_codename %> main restricted" > \
     /target/etc/apt/sources.list.d/00-base.list
-<% else -%>
+<%     else -%>
 echo "<%=url%>" >> \
     /target/etc/apt/sources.list.d/10-barclamp-<%=repo%>.list
-<% end -%>
-<% end -%>
+<%     end
+     end
+   end -%>
 
 rm -f /target/etc/apt/sources.list
 


### PR DESCRIPTION
This pull request adds the following features:

The provisioner and deployer can now handle having more than one repository
per barclamp.

The build system knows how to pull and cache Debian source bundles.

The MySQL barclam has been modified to pull the MySQL source corresponding to
the version of MySQL we are using on Ubuntu builds.

 .../provisioner/recipes/setup_base_images.rb       |   47 +++++++++++---------
 .../provisioner/templates/default/compute.ks.erb   |    6 ++-
 .../templates/default/net-post-install.sh.erb      |   14 +++---
 3 files changed, 39 insertions(+), 28 deletions(-)
