### PR TITLE
Quiet the default verbosity of control.sh [1/5]

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -17,7 +17,7 @@
 # We get the following variables from start-up.sh
 # MAC BOOTDEV ADMIN_IP DOMAIN HOSTNAME HOSTNAME_MAC MYIP
 
-set -x
+[[ $DEBUG ]] && set -x
 
 MYINDEX=${MYIP##*.}
 DHCP_STATE=$(grep -o -E 'crowbar\.state=[^ ]+' /proc/cmdline)


### PR DESCRIPTION
Quiet the default verbosity of control.sh

 updates/control.sh |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)
