### PR TITLE
re-factor out intialize method in controllers [10/22]

### DIFF
--- a/crowbar_framework/app/controllers/provisioner_controller.rb
+++ b/crowbar_framework/app/controllers/provisioner_controller.rb
@@ -14,8 +14,12 @@
 # 
 
 class ProvisionerController < BarclampController
-  def initialize
+  before_filter :set_service_object
+ 
+  def set_service_object
     @service_object = ProvisionerService.new logger
   end
+
+  private :set_service_object
 end
 


### PR DESCRIPTION
Fixed problem with layout rendering due to initialize method not calling super.  Refactored to use before_filter method to load @service_object and deleted initialize method.

 .../app/controllers/provisioner_controller.rb      |   46 +++++++++++---------
 1 files changed, 25 insertions(+), 21 deletions(-)
