### PR TITLE
Fail to PXE boot if we want to boot locally [1/5]

### DIFF
--- a/chef/cookbooks/dhcp/providers/subnet.rb
+++ b/chef/cookbooks/dhcp/providers/subnet.rb
@@ -19,11 +19,10 @@ action :add do
     cookbook "dhcp"
     source "subnet.conf.erb"
     variables(
-      :subnet => new_resource.subnet,
-      :netmask => new_resource.netmask,
-      :broadcast => new_resource.broadcast,
-      :routers => new_resource.routers,
-      :options => new_resource.options
+      :network => new_resource.network,
+      :options => new_resource.options,
+      :pools => new_resource.pools,
+      :pool_options => new_resource.pool_options
     )
     owner "root"
     group "root"

--- a/chef/cookbooks/dhcp/resources/subnet.rb
+++ b/chef/cookbooks/dhcp/resources/subnet.rb
@@ -16,8 +16,8 @@
 actions :add, :remove
 
 attribute :subnet, :kind_of => String, :name_attribute => true
-attribute :broadcast, :kind_of => String
-attribute :netmask, :kind_of => String
-attribute :routers, :kind_of => Array, :default => []
+attribute :network, :kind_of => Mash
+attribute :pools, :kind_of => Array, :default => [ "dhcp" ]
+attribute :pool_options, :kind_of => Hash, :default => { "dhcp" => [ "allow unknown-hosts" ] }
 attribute :options, :kind_of => Array, :default => []
 

--- a/chef/cookbooks/dhcp/templates/default/dhcpd.conf.erb
+++ b/chef/cookbooks/dhcp/templates/default/dhcpd.conf.erb
@@ -14,12 +14,6 @@ omapi-key omapi_key;
 <%= option %>;
   <% end -%>
 <% end -%>
-
-
-next-server <%=@provisioner_ip%>;
-filename "discovery/pxelinux.0";
-
-
 # Use this to send dhcp log messages to a different log file (you also
 # have to hack syslog.conf to complete the redirection).
 log-facility local7;

--- a/chef/cookbooks/dhcp/templates/default/subnet.conf.erb
+++ b/chef/cookbooks/dhcp/templates/default/subnet.conf.erb
@@ -1,14 +1,20 @@
 # File managed by Crowbar
 
-subnet <%= @subnet %> netmask <%= @netmask%> {
-<% unless @routers.nil? or @routers.empty? -%>
-  option routers <%= @routers.collect! {|i| "#{i}" }.join(",") %>;
+subnet <%= @network["subnet"] %> netmask <%= @network["netmask"]%> {
+<% if @network["router"] -%>
+  option routers <%= @network["router"] %>;
 <% end -%>
-  option subnet-mask <%= @netmask %>;
-  option broadcast-address <%= @broadcast %>;
-<% if not @options.empty? -%>
-<%   @options.each do |option| -%>
+  option subnet-mask <%= @network["netmask"] %>;
+  option broadcast-address <%= @network["broadcast"] %>;
+<% @options.each do |option| -%>
   <%= option %>;
 <%   end -%>
+<% @pools.each do |pool| -%>
+   pool {
+     range <%=@network["ranges"][pool]["start"]%> <%=@network["ranges"][pool]["end"]%>;
+     <% @pool_options[pool].each do |opt| -%>
+     <%=opt%>;
+     <% end if @pool_options[pool] -%>
+   }
 <% end -%>
 }

--- a/chef/cookbooks/provisioner/recipes/dhcp_update.rb
+++ b/chef/cookbooks/provisioner/recipes/dhcp_update.rb
@@ -3,18 +3,20 @@
 domain_name = node[:dns].nil? ? node[:domain] : (node[:dns][:domain] || node[:domain])
 admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
 admin_net = node[:network][:networks]["admin"]
-dhcp_start = admin_net[:ranges]["dhcp"]["start"]
-dhcp_end = admin_net[:ranges]["dhcp"]["end"]
 lease_time = node[:provisioner][:dhcp]["lease-time"]
-
+pool_opts = {
+  "dhcp" => ['allow unknown-clients',
+             'filename "discovery/pxelinux.0"',
+             "next-server #{admin_ip}" ],
+  "host" => ['deny unknown-clients']
+}
 dhcp_subnet admin_net["subnet"] do
   action :add
-  broadcast admin_net["broadcast"]
-  netmask admin_net["netmask"]
-  routers (admin_net["router"].nil? ? [] : [ admin_net["router"] ])
+  network admin_net
+  pools ["dhcp","host"]
+  pool_options pool_opts
   options [ "option domain-name \"#{domain_name}\"",
             "option domain-name-servers #{admin_ip}",
-            "range #{dhcp_start} #{dhcp_end}",
             "default-lease-time #{lease_time}",
             "max-lease-time #{lease_time}"]
 end

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -17,7 +17,7 @@ states = node["provisioner"]["dhcp"]["state_machine"]
 tftproot=node["provisioner"]["root"]
 pxecfg_dir="#{tftproot}/discovery/pxelinux.cfg"
 nodes = search(:node, "crowbar_usedhcp:true")
-
+admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
 if not nodes.nil? and not nodes.empty?
   nodes.map{|n|Node.load(n.name)}.each do |mnode|
     Chef::Log.info("Testing if #{mnode[:fqdn]} needs a state transition")
@@ -41,7 +41,6 @@ if not nodes.nil? and not nodes.empty?
     mnode["network"]["interfaces"].each do |net, net_data|
       net_data.each do |field, field_data|
         next if field != "addresses"
-        
         field_data.each do |addr, addr_data|
           next if addr_data["family"] != "lladdr"
           mac_list << addr unless mac_list.include? addr
@@ -56,27 +55,39 @@ if not nodes.nil? and not nodes.empty?
     mac_list.each do |mac|
       count = count+1
       if new_group == "reset" or new_group == "delete"
-        link "#{pxecfg_dir}/01-#{mac.gsub(':','-').downcase}" do
-          action :delete
-        end
         dhcp_host "#{mnode.name}-#{count}" do
           hostname mnode.name
           ipaddress "0.0.0.0"
           macaddress mac
           action :remove
         end
+        link "#{pxecfg_dir}/01-#{mac.gsub(':','-').downcase}" do
+          action :delete
+        end
       else
         # Skip if we don't have admin
         next if admin_data_net.nil?
-
+        if new_group == "execute"
+          dhcp_host "#{mnode.name}-#{count}" do
+            hostname mnode.name
+            ipaddress admin_data_net.address
+            macaddress mac
+            action :add
+          end
+        else
+          dhcp_host "#{mnode.name}-#{count}" do
+            hostname mnode.name
+            ipaddress admin_data_net.address
+            macaddress mac
+            options [
+                     'filename "discovery/pxelinux.0"',
+                     "next-server #{admin_ip}"
+                    ]
+            action :add
+          end
+        end
         link "#{pxecfg_dir}/01-#{mac.gsub(':','-').downcase}" do
           to "#{new_group}"
-        end
-        dhcp_host "#{mnode.name}-#{count}" do
-          hostname mnode.name
-          ipaddress admin_data_net.address
-          macaddress mac
-          action :add
         end
       end
     end


### PR DESCRIPTION
This pull request has the provisioner code refuse to serve the PXE
files to system that we want to boot locally instead of serving them a
file that tells them to boot locally.  It primarily works around a bug
doing localboots from pxelinux in redhat-6.2 on the PEC 6220..

 chef/cookbooks/dhcp/providers/subnet.rb            |    9 +++--
 chef/cookbooks/dhcp/resources/subnet.rb            |    6 ++--
 .../dhcp/templates/default/dhcpd.conf.erb          |    6 ----
 .../dhcp/templates/default/subnet.conf.erb         |   20 +++++++----
 chef/cookbooks/provisioner/recipes/dhcp_update.rb  |   16 +++++----
 chef/cookbooks/provisioner/recipes/update_nodes.rb |   35 +++++++++++++-------
 6 files changed, 52 insertions(+), 40 deletions(-)
