### PR TITLE
Send the hostname as a boot parameter to the sledgehammer image [1/1]

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -189,7 +189,7 @@ if not nodes.nil? and not nodes.empty?
             owner "root"
             group "root"
             source t[:src]
-            variables(:append_line => "#{node[:provisioner][:sledgehammer_append_line]} crowbar.state=#{new_group}",
+            variables(:append_line => "#{node[:provisioner][:sledgehammer_append_line]} crowbar.hostname=#{mnode[:fqdn]} crowbar.state=#{new_group}",
                       :install_name => new_group,
                       :initrd => "initrd0.img",
                       :kernel => "vmlinuz0")


### PR DESCRIPTION
In some cases, the system can change nic boot order after booting.
This mainly happens when changing from bios to uefi boot modes.

To prevent the node from getting lost, the hostname should be derived
from the boot parameters and not the BOOTIF.

 chef/cookbooks/provisioner/recipes/update_nodes.rb |    2 +-
 updates/control.sh                                 |   26 ++++++++++++++++++++
 2 files changed, 27 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: c6cd99098a4a1d58862be9fd1eb9e6325094f9d5

Crowbar-Release: fred
