### PR TITLE
Handle case where there is no by-id name for the first device in the box. [1/1]

### DIFF
--- a/chef/cookbooks/provisioner/recipes/bootdisk.rb
+++ b/chef/cookbooks/provisioner/recipes/bootdisk.rb
@@ -25,10 +25,14 @@ ruby_block "Find the fallback boot device" do
       f="#{basedir}/#{m}"
       File.symlink?(f) && (File.readlink(f).split('/')[-1] == dev)
     end
-    bootdisk = bootdisks.find{|b|b =~ /^scsi-/} ||
-      bootdisks.find{|b|b =~ /^ata-/} ||
-      bootdisks.first
-    node[:crowbar_wall][:boot_device] = "disk/by-id/#{bootdisk}"
+    if bootdisks.empty?
+      node[:crowbar_wall][:boot_device] = dev
+    else
+      bootdisk = bootdisks.find{|b|b =~ /^scsi-/} ||
+        bootdisks.find{|b|b =~ /^ata-/} ||
+        bootdisks.first
+      node[:crowbar_wall][:boot_device] = "disk/by-id/#{bootdisk}"
+    end
     node.save
   end
   not_if do node[:crowbar_wall][:boot_device] end


### PR DESCRIPTION
VMWare does not give its fake block devices serial numbers, so there
are by-id links for vmware disks running under it.

 chef/cookbooks/provisioner/recipes/bootdisk.rb |   12 ++++++++----
 1 file changed, 8 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: c61c36b747b16cc97370c292ca1a75b91bd7fc59

Crowbar-Release: fred
