### PR TITLE
smoked build [2/2]

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -173,12 +173,6 @@ EOH
   not_if "test -f #{tftproot}/validation.pem"
 end
 
-# put our statically-linked curl into place
-directory "/tftpboot/curl"
-bash "copy curl into place" do
-  code "cp /tftpboot/files/curl /tftpboot/curl/"
-  not_if do ::File.exist?("/tftpboot/curl/curl") end
-end
 
 # By default, install the same OS that the admin node is running
 # If the comitted proposal has a defualt, try it.

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -114,6 +114,7 @@ rpms:
     - tftp-server
     - xinetd
     - nginx
+    - curl
   build_pkgs:
     - flex
     - bison
@@ -122,7 +123,7 @@ rpms:
     - gcc
     - glibc-devel
 
-extra_files:
-  - http://curl.haxx.se/download/curl-7.23.1.tar.gz
+#extra_files:
+#  - http://curl.haxx.se/download/curl-7.23.1.tar.gz
 
-build_cmd: build_curl.sh
+#build_cmd: build_curl.sh


### PR DESCRIPTION
Minor catchups:
- no longer need to use our own built curl (provisioner)
- pi2py needs to be installed with sudo (git)
  
  .../provisioner/recipes/setup_base_images.rb       |    6 ------
  crowbar.yml                                        |    7 ++++---
  2 files changed, 4 insertions(+), 9 deletions(-)

Crowbar-Pull-ID: 92b250cedd0aa49cf6d00c96501dee04b8872515

Crowbar-Release: feature/pfs-folsom
