### PR TITLE
Epic rename of CMDB to Jig [2/6]

### DIFF
--- a/crowbar_framework/app/controllers/provisioner_controller.rb
+++ b/crowbar_framework/app/controllers/provisioner_controller.rb
@@ -49,7 +49,7 @@ class ProvisionerController < BarclampController
   private
   def get_oses
     provisioners = Node.find_by_role_name('provisioner-server')
-    provisioners ? provisioners.map{|n|n.cmdb_hash["provisioner"]["available_oses"].keys}.flatten.sort.uniq : []
+    provisioners ? provisioners.map{|n|n.jig_hash["provisioner"]["available_oses"].keys}.flatten.sort.uniq : []
   end
 end
 

--- a/crowbar_framework/app/models/provisioner_service.rb
+++ b/crowbar_framework/app/models/provisioner_service.rb
@@ -88,7 +88,7 @@ class ProvisionerService < ServiceObject
       provisioner = Node.find_by_role_name('provisioner-server')
       if provisioner &&
           provisioner[0] &&
-          provisioner[0].cmdb_hash["provisioner"]["available_oses"][target_os]
+          provisioner[0].jig_hash["provisioner"]["available_oses"][target_os]
         nstate = "#{target_os}_install"
       else
         return [500, "#{node.name} wants to install #{target_os}, but #{name} doesn't know how to do that!"]
@@ -97,7 +97,7 @@ class ProvisionerService < ServiceObject
 
     node_hash["provisioner_state"] = nstate
     prop_config.set_node_config_hash(node, node_hash)
-    node.update_cmdb
+    node.update_jig
 
     # We need a real process runner here.
     # Blocking Puma to wait on these state transitions is bad, mmkay?


### PR DESCRIPTION
CMDB as a name is confusing and does not fit with our tool-related
naming scheme.  Jig, on the other hand, is an awesome fit for what
CMDB does and it fits the naming scheme.

 .../app/controllers/provisioner_controller.rb      |    2 +-
 .../app/models/provisioner_service.rb              |    4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: 902f781dd496ff9c1ed7cfa95126b038e665e7c9

Crowbar-Release: development
