### PR TITLE
Kill our remembered boot_device across a node reset. [1/2]

### DIFF
--- a/crowbar_framework/app/models/provisioner_service.rb
+++ b/crowbar_framework/app/models/provisioner_service.rb
@@ -93,6 +93,12 @@ class ProvisionerService < ServiceObject
       add_role_to_instance_and_node("provisioner",inst,name,db,role,"provisioner-bootdisk-finder")
     end
 
+    if state == "reset"
+      node = NodeObject.find_node_by_name(name)
+      node[:crowbar_wall][:boot_device] = nil if (node[:crowbar_wall][:boot_device] rescue nil)
+      node.save
+    end
+
     if state == "delete"
       # BA LOCK NOT NEEDED HERE.  NODE IS DELETING
       node = NodeObject.find_node_by_name(name)


### PR DESCRIPTION
If we are resetting a node's state, we don't want to remember what device
we were booting from.  So, when a node goes through a reset state, we kill
the boot_device entry in the crowbar_wall.

Also fix up an error that was causing reset to error out in a virtual
environment -- the reset code assumed a working BMC, when we do not
necessarily have one.

 .../app/models/provisioner_service.rb              |    6 ++++++
 1 file changed, 6 insertions(+)

Crowbar-Pull-ID: f1e4ea797ca7b956a0c90301bd38ef8eed4e242e

Crowbar-Release: fred
