### PR TITLE
Epic rename of cmdb to jig, for real this time. [2/7]

### DIFF
--- a/crowbar_framework/app/controllers/provisioner_controller.rb
+++ b/crowbar_framework/app/controllers/provisioner_controller.rb
@@ -49,7 +49,7 @@ class ProvisionerController < BarclampController
   private
   def get_oses
     provisioners = Node.find_by_role_name('provisioner-server')
-    provisioners ? provisioners.map{|n|n.cmdb_hash["provisioner"]["available_oses"].keys}.flatten.sort.uniq : []
+    provisioners ? provisioners.map{|n|n.jig_hash["provisioner"]["available_oses"].keys}.flatten.sort.uniq : []
   end
 end
 

--- a/crowbar_framework/app/models/provisioner_service.rb
+++ b/crowbar_framework/app/models/provisioner_service.rb
@@ -88,7 +88,7 @@ class ProvisionerService < ServiceObject
       provisioner = Node.find_by_role_name('provisioner-server')
       if provisioner &&
           provisioner[0] &&
-          provisioner[0].cmdb_hash["provisioner"]["available_oses"][target_os]
+          provisioner[0].jig_hash["provisioner"]["available_oses"][target_os]
         nstate = "#{target_os}_install"
       else
         return [500, "#{node.name} wants to install #{target_os}, but #{name} doesn't know how to do that!"]
@@ -97,7 +97,7 @@ class ProvisionerService < ServiceObject
 
     node_hash["provisioner_state"] = nstate
     prop_config.set_node_config_hash(node, node_hash)
-    node.update_cmdb
+    node.update_jig
 
     # We need a real process runner here.
     # Blocking Puma to wait on these state transitions is bad, mmkay?


### PR DESCRIPTION
This pull request series renames cmdb to jig across the entire Crowbar
codebase.

You can replicate its effects if you get a merge conflict with the
following commands:

cd barclamps
for bc in _; do
    (   cd "$bc" || continue
        git checkout master)
done
cd ..
while read -r f; do
    sed -i -e 's/cmdb/jig/g' -e 's/CMDB/Jig/g' -e 's/Cmdb/Jig/g' "$f"
    (   cd "${f%/_}"
        git add "${f##_/}")
done < <(grep --binary-files=without-match -irl cmdb \* |grep -v '.git')
while read f; do
    (   cd "${f%/_}"
        file="${f##_/}"
        git mv "$file" "${file//cmdb/jig}")
done < <(find -type f -name '_cmdb*' |grep -v '/.git/')
git commit -m "Epic rename of cmdb to jig"
cd barclamps
for bc in *; do
    (   cd "$bc" || continue
        git commit -m "Epic rename of cmdb to jig");
done
cd ..

 .../app/controllers/provisioner_controller.rb      |    2 +-
 .../app/models/provisioner_service.rb              |    4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: ca715c91ecfe7b42a192c575f9a6289aeb4c9007

Crowbar-Release: development
