### PR TITLE
First pass at getting native package based installs working on Uubntu and Redhat. [2/6]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -6,7 +6,6 @@
       "online": false,
       "upstream_proxy": "",
       "default_user": "crowbar",
-      "default_os": "%default_os%",
       "default_password_hash": "$1$BDC3UwFr$/VqOWN1Wi6oM0jiMOjaPb.",
       "supported_oses": {
         "ubuntu-10.10": {

--- a/chef/data_bags/crowbar/bc-template-provisioner.schema
+++ b/chef/data_bags/crowbar/bc-template-provisioner.schema
@@ -16,8 +16,8 @@
             "upstream_proxy": { "type": "str", "required": false },
             "default_user": { "type": "str", "required": true },
             "default_password": { "type": "str" },
+            "default_os": { "type": "str", "required": false },
             "default_password_hash": { "type": "str" },
-	    "default_os": { "type": "str", "required": true },
             "web_port": { "type": "int", "required": true },
 	    "root": { "type": "str", "required": true },
 	    "supported_oses": {


### PR DESCRIPTION
This is a nonfunctional attempt at getting and admin node installed
using OS native packages for Ubuntu and Debian.  The codepaths for the
traditional Dell build and admin node codepaths have the following
changes:

1: Crowbar package cache generation for the admin node was moved to
the post-install phase of the relavent OS deploys for the admin node.
This was done so that the post-install script will have the tools
necessary to generate repository metadata for the native barclamp
packages.

2: The crowbar framework no longer requires a declaration for
the machine-install user in the default proposal for the Crowbar
barclamp.  Instead, it will create the machine-install user with a
random password when the crowbar barclamp is set up. The login
information for the machine-install user will continue to be stored in
/etc/crowbar.install.key.

3: The DNS barclamp will detect when you are deploying with an
unmodified default proposal and attempt to rewrite the domain
information to match the current state of the admin node.

4: The provisioner no longer needs to be told what the default OS is.
It will infer it based on the OS the admin node is using if not told
via proposal.

These changes help by allowing us to deploy an admin node without
having to hack up proposal templates with sed as part of the install
process.

 .../data_bags/crowbar/bc-template-provisioner.json |    1 -
 .../crowbar/bc-template-provisioner.schema         |    2 +-
 2 files changed, 1 insertion(+), 2 deletions(-)

Crowbar-Pull-ID: 5a61c0feb8bea25dbf1b92b356a5c55f23cd28ba

Crowbar-Release: development
