### PR TITLE
Fixups to add enough default attributes to some roles to test them on an admin node. [2/7]

### DIFF
--- a/chef/roles/provisioner-base.rb
+++ b/chef/roles/provisioner-base.rb
@@ -1,9 +1,8 @@
 
 name "provisioner-base"
 description "Provisioner Base role - Apt and Networking"
-run_list( 
+run_list(
          "recipe[provisioner::base]",
-         "recipe[utils]", 
-         "recipe[barclamp]" 
+         "recipe[utils]",
+         "recipe[barclamp]"
 )
-

--- a/chef/roles/provisioner-server.rb
+++ b/chef/roles/provisioner-server.rb
@@ -2,13 +2,67 @@
 name "provisioner-server"
 description "Provisioner Server role - Apt and Networking"
 run_list(
-         "recipe[utils]", 
+         "recipe[utils]",
          "recipe[dhcp]",
          "recipe[nfs-server]",
          "recipe[provisioner::dhcp_update]",
          "recipe[provisioner::setup_base_images]",
          "recipe[provisioner::update_nodes]"
 )
-default_attributes()
+default_attributes "provisioner" => {
+  "online" => false,
+  "upstread_proxy" => "",
+  "default_user" => "crowbar",
+  "default_password_hash" => "$1$BDC3UwFr$/VqOWN1Wi6oM0jiMOjaPb.",
+  "supported_oses" => {
+    "ubuntu-12.04" => {
+      "initrd" => "install/netboot/ubuntu-installer/amd64/initrd.gz",
+      "kernel" => "install/netboot/ubuntu-installer/amd64/linux",
+      "append" => "debian-installer/locale=en_US.utf8 console-setup/layoutcode=us keyboard-configuration/layoutcode=us netcfg/dhcp_timeout=120 netcfg/choose_interface=auto root=/dev/ram rw quiet --",
+      "online_mirror" => "http://us.archive.ubuntu.com/ubuntu/",
+      "codename" => "precise"
+    },
+    "redhat-6.2" => {
+      "initrd" => "images/pxeboot/initrd.img",
+      "kernel" => "images/pxeboot/vmlinuz",
+      "append" => "method=%os_install_site%"
+    },
+    "centos-6.2" => {
+      "initrd" => "images/pxeboot/initrd.img",
+      "kernel" => "images/pxeboot/vmlinuz",
+      "append" => "method=%os_install_site%",
+      "online_mirror" => "http://mirror.centos.org/centos/6/"
+    },
+    "suse-11.2" => {
+      "initrd" => "boot/x86_64/loader/initrd",
+      "kernel" => "boot/x86_64/loader/linux",
+      "append" => "install=%os_install_site%"
+    },
+    "root" => "/tftpboot",
+    "web_port" => 8091,
+    "use_local_security" => true,
+    "use_serial_console" => false,
+    "dhcp" => {
+      "lease-time" => 60,
+      "state_machine" => {
+        "debug" => "debug",
+        "delete" => "delete",
+        "discovered" => "discovery",
+        "discovering" => "discovery",
+        "hardware-installed" => "os_install",
+        "hardware-installing" => "hwinstall",
+        "hardware-updated" => "execute",
+        "hardware-updating" => "update",
+        "installed" => "execute",
+        "installing" => "os_install",
+        "ready" => "execute",
+        "readying" => "execute",
+        "reinstall" => "os_install",
+        "reset" => "reset",
+        "update" => "update"
+      }
+    }
+  },
+  "config" => { "environment" => "provisioner-base-config" }
+}
 override_attributes()
-


### PR DESCRIPTION
Aside from Chef 11 fixups, the default attributes are inteded to be a
placeholder until the chef jig is working well enough to handle
attribute import and export.

Roles that have been validated so far are:
- deployer-client
- dns-client
- ntp-server
- logging-server

Roles that have been half-validated (recipes run without error, but
functionality is missing:
- bmc-nat-router: Needs the network BC to have injected attributed
  for the networks onto the node.
- dns-server: Ditto

Roles that have nbeen modified, but not tested:
- logging-client:  Cannot test until we have another node, as
  logging-client and logging-server cannot coexist on the same node.
- ipmi-discover and ipmi-configure: Need real hardware to
  meaningfully test these barclamps.
- provisioner-base and provisioner-server:  Need a semi-functional
  DNS server and network BC to make any reasonable progress here.
  
  chef/roles/provisioner-base.rb   |    7 ++---
  chef/roles/provisioner-server.rb |   60 ++++++++++++++++++++++++++++++++++++--
  2 files changed, 60 insertions(+), 7 deletions(-)

Crowbar-Pull-ID: c57e28f294ea94c640dee96a8a8c4ce5db59bb8e

Crowbar-Release: development
