### PR TITLE
Add enough default attributes to some roles to test them on an admin server. [2/7]

### DIFF
--- a/chef/roles/provisioner-base.rb
+++ b/chef/roles/provisioner-base.rb
@@ -1,9 +1,8 @@
 
 name "provisioner-base"
 description "Provisioner Base role - Apt and Networking"
-run_list( 
+run_list(
          "recipe[provisioner::base]",
-         "recipe[utils]", 
-         "recipe[barclamp]" 
+         "recipe[utils]",
+         "recipe[barclamp]"
 )
-

--- a/chef/roles/provisioner-server.rb
+++ b/chef/roles/provisioner-server.rb
@@ -2,13 +2,67 @@
 name "provisioner-server"
 description "Provisioner Server role - Apt and Networking"
 run_list(
-         "recipe[utils]", 
+         "recipe[utils]",
          "recipe[dhcp]",
          "recipe[nfs-server]",
          "recipe[provisioner::dhcp_update]",
          "recipe[provisioner::setup_base_images]",
          "recipe[provisioner::update_nodes]"
 )
-default_attributes()
+default_attributes "provisioner" => {
+  "online" => false,
+  "upstread_proxy" => "",
+  "default_user" => "crowbar",
+  "default_password_hash" => "$1$BDC3UwFr$/VqOWN1Wi6oM0jiMOjaPb.",
+  "supported_oses" => {
+    "ubuntu-12.04" => {
+      "initrd" => "install/netboot/ubuntu-installer/amd64/initrd.gz",
+      "kernel" => "install/netboot/ubuntu-installer/amd64/linux",
+      "append" => "debian-installer/locale=en_US.utf8 console-setup/layoutcode=us keyboard-configuration/layoutcode=us netcfg/dhcp_timeout=120 netcfg/choose_interface=auto root=/dev/ram rw quiet --",
+      "online_mirror" => "http://us.archive.ubuntu.com/ubuntu/",
+      "codename" => "precise"
+    },
+    "redhat-6.2" => {
+      "initrd" => "images/pxeboot/initrd.img",
+      "kernel" => "images/pxeboot/vmlinuz",
+      "append" => "method=%os_install_site%"
+    },
+    "centos-6.2" => {
+      "initrd" => "images/pxeboot/initrd.img",
+      "kernel" => "images/pxeboot/vmlinuz",
+      "append" => "method=%os_install_site%",
+      "online_mirror" => "http://mirror.centos.org/centos/6/"
+    },
+    "suse-11.2" => {
+      "initrd" => "boot/x86_64/loader/initrd",
+      "kernel" => "boot/x86_64/loader/linux",
+      "append" => "install=%os_install_site%"
+    },
+    "root" => "/tftpboot",
+    "web_port" => 8091,
+    "use_local_security" => true,
+    "use_serial_console" => false,
+    "dhcp" => {
+      "lease-time" => 60,
+      "state_machine" => {
+        "debug" => "debug",
+        "delete" => "delete",
+        "discovered" => "discovery",
+        "discovering" => "discovery",
+        "hardware-installed" => "os_install",
+        "hardware-installing" => "hwinstall",
+        "hardware-updated" => "execute",
+        "hardware-updating" => "update",
+        "installed" => "execute",
+        "installing" => "os_install",
+        "ready" => "execute",
+        "readying" => "execute",
+        "reinstall" => "os_install",
+        "reset" => "reset",
+        "update" => "update"
+      }
+    }
+  },
+  "config" => { "environment" => "provisioner-base-config" }
+}
 override_attributes()
-


### PR DESCRIPTION
Roles that have been tested:

roles for server:
   deployer-client -- OK
   bmc-nat-router -- OK
   dns-server -- tested, will need network bc.
   dns-client -- OK
   ntp-server -- OK
   logging-server -- OK
   logging-client -- not tested, cannot run with logging-server
   ipmi-discover -- not tested, need real hardware
   ipmi-configure -- not tested, need real hardware
   provisioner-base -- not tested, need working DNS and network.
   provisioner-server -- Not tested, need working DNS and network.

 chef/roles/provisioner-base.rb   |    7 ++---
 chef/roles/provisioner-server.rb |   60 ++++++++++++++++++++++++++++++++++++--
 2 files changed, 60 insertions(+), 7 deletions(-)

Crowbar-Pull-ID: b29260d1a62efa73a3928f732a6a1e5316498543

Crowbar-Release: development
