### PR TITLE
Add opensuse 12.2 as a supported os

### DIFF
--- a/bc-template-provisioner.json
+++ b/bc-template-provisioner.json
@@ -67,6 +67,11 @@
          "initrd": "boot/x86_64/loader/initrd",
          "kernel": "boot/x86_64/loader/linux",
          "append": "install=%os_install_site%"
+        },
+        "suse-12.2": {
+         "initrd": "boot/x86_64/loader/initrd",
+         "kernel": "boot/x86_64/loader/linux",
+         "append": "install=%os_install_site%"
         }
 
       },

--- a/chef/roles/provisioner-server.rb
+++ b/chef/roles/provisioner-server.rb
@@ -37,6 +37,11 @@ default_attributes "provisioner" => {
       "initrd" => "boot/x86_64/loader/initrd",
       "kernel" => "boot/x86_64/loader/linux",
       "append" => "install=%os_install_site%"
+    },
+    "suse-12.2" => {
+      "initrd" => "boot/x86_64/loader/initrd",
+      "kernel" => "boot/x86_64/loader/linux",
+      "append" => "install=%os_install_site%"
     }
   },
   "root" => "/tftpboot",


### PR DESCRIPTION
To make the "zombie provisioner mode" work on openSUSE as well. :)
