### PR TITLE
Avoid trying to install rubygem-cstruct more throughly when not on sleshammer. [1/2]

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/control.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/control.sh.erb
@@ -18,23 +18,29 @@
 # MAC BOOTDEV ADMIN_IP DOMAIN HOSTNAME HOSTNAME_MAC MYIP
 
 [[ $DEBUG ]] && set -x
-# Get our passed-in hostname
-HOSTNAME=$(grep -o -E 'crowbar\.fqdn=[^ ]+' /proc/cmdline)
-if [[ ! $HOSTNAME ]]; then
-    # We did not get handed a hostname.
-    # Create one based on the MAC we booted from, and
-    # create a new host entry based off it.
-    HOSTNAME="d${MAC//:/-}.${DOMAIN}"
-    curl --digest -u "$CROWBAR_KEY" -X POST \
-        -d "name=$HOSTNAME" \
-        http://192.168.124.10:3000/api/v2/nodes/
+if [[ ! $IN_CONTROL_SH ]]; then
+    # Get our passed-in hostname
+    HOSTNAME=$(grep -o -E 'crowbar\.fqdn=[^ ]+' /proc/cmdline)
+    if [[ ! $HOSTNAME ]]; then
+        # We did not get handed a hostname.
+        # Create one based on the MAC we booted from, and
+        # create a new host entry based off it.
+        HOSTNAME="d${MAC//:/-}.${DOMAIN}"
+        curl --digest -u "$CROWBAR_KEY" -X POST \
+            -d "name=$HOSTNAME" \
+            http://192.168.124.10:3000/api/v2/nodes/
+    fi
+    sed -i -e "s/\(127\.0\.0\.1.*\)/127.0.0.1 $HOSTNAME ${HOSTNAME%%.*} localhost.localdomain localhost/" /etc/hosts
+    if [[ -f /etc/sysconfig/network ]]; then
+        sed -i -e "s/HOSTNAME=.*/HOSTNAME=${HOSTNAME}/" /etc/sysconfig/network
+    fi
+    echo "${HOSTNAME#*.}" >/etc/domainname
+    hostname "$HOSTNAME"
+
+    IN_CONTROL_SH=true
+    export HOSTNAME IN_CONTROL_SH
+    exec script -a -f -c "$0 $@" /install-logs/$HOSTNAME-control.log
 fi
-sed -i -e "s/\(127\.0\.0\.1.*\)/127.0.0.1 $HOSTNAME ${HOSTNAME%%.*} localhost.localdomain localhost/" /etc/hosts
-if [[ -f /etc/sysconfig/network ]]; then
-    sed -i -e "s/HOSTNAME=.*/HOSTNAME=${HOSTNAME}/" /etc/sysconfig/network
-fi
-echo "${HOSTNAME#*.}" >/etc/domainname
-hostname "$HOSTNAME"
 
 MYINDEX=${MYIP##*.}
 DHCP_STATE=$(grep -o -E 'crowbar\.state=[^ ]+' /proc/cmdline)


### PR DESCRIPTION
- We do not install OS packages on Sledgehammer as a matter of course, so do not do anything that will even try to trigger the package manager.  This fixes the initial chef-client run on the deployer.
- Keep a full transcript of every control.sh run on the deployer.
  
  .../provisioner/templates/default/control.sh.erb   |   38 +++++++++++---------
  1 file changed, 22 insertions(+), 16 deletions(-)

Crowbar-Pull-ID: e702b3a21f5294cf6fa2c3851e3015ac5842fb49

Crowbar-Release: development
