### PR TITLE
Make the computer nodes sit there and idle after transition to discovered. [1/1]

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/control.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/control.sh.erb
@@ -225,6 +225,9 @@ hwupdate () {
 
 run_chef_client
 
+__post_state discovered
+exit 0
+
 case $DHCP_STATE in
     discovery) discover && hardware_install;;
     hwinstall) hardware_install;;


### PR DESCRIPTION
Instead of rebooting, just have the nodes transition to discovered
and drop to a login prompt.

 .../provisioner/templates/default/control.sh.erb   |    3 +++
 1 file changed, 3 insertions(+)

Crowbar-Pull-ID: 2773e6b73857b4b3bf97020b60d6ea14df789fd7

Crowbar-Release: development
