### PR TITLE
Make feature/grizzly a little more amenable to being built in the Dell build and test env. [10/11]

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -17,7 +17,12 @@
 # We get the following variables from start-up.sh
 # MAC BOOTDEV ADMIN_IP DOMAIN HOSTNAME HOSTNAME_MAC MYIP
 
-[[ $DEBUG ]] && set -x
+if [[ ! $IN_SCRIPT ]]; then
+    export IN_SCRIPT=true
+    script -a -f -c "$0" "/install-logs/$HOSTNAME_MAC.transcript"
+fi
+set -x
+export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
 
 MYINDEX=${MYIP##*.}
 DHCP_STATE=$(grep -o -E 'crowbar\.state=[^ ]+' /proc/cmdline)


### PR DESCRIPTION
This pull request series starts at making PFS builds use the build
cache in a wway that is compatible with performing offline builds.
- Reorder the cache staging processes in the main build process to
  stage things cache by cache instead of barclamp by barclamp.  This
  ensures that all custom barclamp build actions can see the complete
  state of the cache for all barclamps, instead of only seeing the
  cache of the barclamps that were staged before them.
- Add support for stashing the complete barclamp metadata from the
  crowbar.yml files into the barclamps data bag in Chef.
- Add support into the build system for making complete clones of git
  repositories and saving them as tar.bz2 files in the build cache.
- Erase the git barclamp's custom build action for staging git
  repositories.  The build system handles this for us now.
- Fix up the git barclamp to conform to how the build system staged
  cached git repository clones.
- Fix up the crowbar.yml files to be ruby 1.9 compatible
- Several misc. bugfixes.

Still to be done is to intergrate PIP cache handling into the main
build system -- curently, we only use this functionality for PFS.

This patch series also slightly modifies how one invokes a PFS build.
Specifically, you need to pass the --update-pfs-caches flag to allow
the build system to clone or update its cached git checkouts.

 updates/control.sh |    7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 9a77ef6723b715acfb8d892036d330758f85a940

Crowbar-Release: feature/grizzly
