### PR TITLE
Update Bluepill recipes fix unwanted restarts of chef-server bits during admin node bringup. [1/2]

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/provisioner-webserver.pill.erb
+++ b/chef/cookbooks/provisioner/templates/default/provisioner-webserver.pill.erb
@@ -1,11 +1,9 @@
-Bluepill.application("<%= @appname %>") do |app|
-  app.process("<%= @appname %>") do |process|
-    process.start_command = '/usr/bin/ruby -rwebrick -e WEBrick::HTTPServer.new(:Port=><%= @port %>,:DocumentRoot=>\".\").start'
-    process.stop_signals = [:kill]
-    process.stop_grace_time = 5.seconds
-    process.uid = "nobody"
-    process.working_dir = "<%= @docroot %>"
-    process.stdout = process.stderr = "<%= @logfile %>"
-    process.daemonize = true
+Bluepill.application("provisioner-webserver") do |app|
+  app.process("provisioner-webserver") do |p|
+    p.name = "provisioner-webserver"
+    p.start_command = "nginx -c /etc/nginx/provisioner.conf"
+    p.stdout = p.stderr = "/var/log/provisioner-webserver.log"
+    p.pid_file = "/var/run/provisioner-webserver.pid"
+    p.daemonize = false
   end
 end

--- a/chef/cookbooks/provisioner/templates/default/tftpd.pill.erb
+++ b/chef/cookbooks/provisioner/templates/default/tftpd.pill.erb
@@ -1,0 +1,8 @@
+Bluepill.application("tftpd") do |app|
+  app.process("tftpd") do |p|
+    p.name = "tftpd"
+    p.start_command = "in.tftpd -4 -L -a 0.0.0.0:69 -s <%=@tftproot%>"
+    p.stdout = p.stderr = "/dev/null"
+    p.daemonize = true
+  end
+end


### PR DESCRIPTION
This pull request updates Bluepill to fix some regressions in bringing up
managed services without unneeded reboots.

Among other things, this will downgrade the BLuepill gem to version 0.0.51

 .../provisioner/recipes/setup_base_images.rb       |   45 +++++++++++---------
 .../default/provisioner-webserver.pill.erb         |   16 +++----
 .../provisioner/templates/default/tftpd.pill.erb   |    8 ++++
 3 files changed, 40 insertions(+), 29 deletions(-)

Crowbar-Pull-ID: c8d247c4c8237da96dc8c063f018bf8cb6230172

Crowbar-Release: pebbles
