### PR TITLE
DE1118- RHEL fix to select the first active link by default [1/1]

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -141,7 +141,7 @@ if not nodes.nil? and not nodes.empty?
                       :install_path => "#{os}/install")
           end
         when os =~ /^(redhat|centos)/
-          append << "ks=#{node_url}/compute.ks method=#{install_url}"
+          append << "ks=#{node_url}/compute.ks method=#{install_url} ksdevice=link"
           template "#{node_cfg_dir}/compute.ks" do
             mode 0644
             source "compute.ks.erb"


### PR DESCRIPTION
Fixes a problem during RHEL install when there are multiple nics. This selects the first active link and does not prompt user.

 chef/cookbooks/provisioner/recipes/update_nodes.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: a923e5141703828b8af1713827a3801b5bca13f3

Crowbar-Release: pebbles
