### PR TITLE
Allow configurable timezones that default to UTC. [1/1]

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -15,6 +15,7 @@
 
 states = node["provisioner"]["dhcp"]["state_machine"]
 tftproot=node["provisioner"]["root"]
+timezone = (node["provisioner"]["timezone"] rescue "UTC") || "UTC"
 pxecfg_dir="#{tftproot}/discovery/pxelinux.cfg"
 uefi_dir="#{tftproot}/discovery"
 admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
@@ -137,6 +138,7 @@ if not nodes.nil? and not nodes.empty?
                       :cc_install_web_port => web_port,
                       :boot_device => (mnode[:crowbar_wall][:boot_device] rescue nil),
                       :cc_built_admin_node_ip => admin_ip,
+                      :timezone => timezone,
                       :node_name => mnode[:fqdn],
                       :install_path => "#{os}/install")
           end
@@ -155,6 +157,7 @@ if not nodes.nil? and not nodes.empty?
                       :repos => node[:provisioner][:repositories][os],
                       :uefi => (mnode[:crowbar_wall][:uefi] rescue nil),
                       :admin_web => install_url,
+                      :timezone => timezone,
                       :crowbar_join => "#{os_url}/crowbar_join.sh")
           end
         when os =~ /^(open)?suse/
@@ -167,6 +170,7 @@ if not nodes.nil? and not nodes.empty?
             variables(
                       :admin_node_ip => admin_ip,
                       :web_port => web_port,
+                      :timezone => timezone,
                       :boot_device => (mnode[:crowbar_wall][:boot_device] rescue nil),
                       :node_name => mnode[:fqdn],
                       :crowbar_join => "#{os_url}/crowbar_join.sh")

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -36,6 +36,10 @@
          <surname/>
       </user>
   </users>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone><%=@timezone%></timezone>
+  </timezone>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
     <dns>

--- a/chef/cookbooks/provisioner/templates/default/compute.ks.erb
+++ b/chef/cookbooks/provisioner/templates/default/compute.ks.erb
@@ -14,7 +14,7 @@ rootpw <%= node[:provisioner][:default_password] %>
 firewall --disabled
 authconfig --enableshadow --enablemd5
 selinux --disabled
-timezone --utc UTC
+timezone --utc <%=@timezone%>
 bootloader --location=mbr --driveorder=<%= @boot_device || "sda" %> --append="rhgb quiet"
 zerombr
 <% if node[:platform_version].to_f >= 6 -%>

--- a/chef/cookbooks/provisioner/templates/default/net_seed.erb
+++ b/chef/cookbooks/provisioner/templates/default/net_seed.erb
@@ -90,7 +90,7 @@ d-i clock-setup/utc boolean true
 
 # You may set this to any valid setting for $TZ; see the contents of
 # /usr/share/zoneinfo/ for valid values.
-d-i time/zone string US/Central
+d-i time/zone string <%=@timezone%>
 
 # Controls whether to use NTP to set the clock during the install
 d-i clock-setup/ntp boolean false

--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -38,6 +38,7 @@
         }
       },
       "root": "/tftpboot",
+      "timezone": "UTC",
       "web_port": 8091,
       "use_local_security": true,
       "use_serial_console": false,

--- a/chef/data_bags/crowbar/bc-template-provisioner.schema
+++ b/chef/data_bags/crowbar/bc-template-provisioner.schema
@@ -17,6 +17,7 @@
             "default_password_hash": { "type": "str" },
             "web_port": { "type": "int", "required": true },
 	    "root": { "type": "str", "required": true },
+            "timezone": { "type": "str", "required": true },
 	    "default_os": { "type": "str", "required": false },
 	    "supported_oses": {
 	      "type": "map",


### PR DESCRIPTION
This pull requests adds support for setting the default timezone at OS
install time.  By default, the timezone defaults to UTC, but it can be
changed to any valid timezone by editing the provisioner proposal.

Closes DE632.

 chef/cookbooks/provisioner/recipes/update_nodes.rb |    4 ++++
 .../provisioner/templates/default/autoyast.xml.erb |    4 ++++
 .../provisioner/templates/default/compute.ks.erb   |    2 +-
 .../provisioner/templates/default/net_seed.erb     |    2 +-
 .../data_bags/crowbar/bc-template-provisioner.json |    1 +
 .../crowbar/bc-template-provisioner.schema         |    1 +
 6 files changed, 12 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 82bfeac19d5b828346a06b86c629070afd6edfd2

Crowbar-Release: pebbles
