### PR TITLE
bootdisk: Do not fail if there's no id for any device

### DIFF
--- a/chef/cookbooks/provisioner/recipes/bootdisk.rb
+++ b/chef/cookbooks/provisioner/recipes/bootdisk.rb
@@ -9,16 +9,19 @@ ruby_block "Find the fallback boot device" do
   block do
     basedir="/dev/disk/by-path"
     dev=nil
+    disk_by_path = nil
     ::Dir.entries(basedir).sort.each do |path|
       # Not a symlink?  Not interested.
       next unless File.symlink?("#{basedir}/#{path}")
       # Symlink does not point at a disk?  Also not interested.
       dev = File.readlink("#{basedir}/#{path}").split('/')[-1]
+      disk_by_path = "disk/by-path/#{path}"
       break if dev =~ /^[hsv]d[a-z]+$/
       dev = nil
+      disk_by_path = nil
     end
     raise "Cannot find a hard disk!" unless dev
-    node[:crowbar_wall][:boot_device] = dev
+    node[:crowbar_wall][:boot_device] = disk_by_path
     # Turn the found device into its corresponding /dev/disk/by-id link.
     # This name should be more stable than the /dev/disk/by-path one.
     basedir="/dev/disk/by-id"


### PR DESCRIPTION
If no device has an id, then /dev/disk/by-id doesn't exist (here, at
least), and an exception is raised when listing the content of that
directory. This results in node[:crowbar_wall][:boot_device] never being
set and therefore a failure during install if the boot disk is not sda.

This fixes bootdisk on my test setup (qemu/kvm doesn't set id for disks
by default).
