### PR TITLE
control.sh: Make wait_for_allocated more solid

### DIFF
--- a/updates/control_lib.sh
+++ b/updates/control_lib.sh
@@ -86,10 +86,9 @@ reboot_system() {
 
 wait_for_allocated() {
     # $1 = hostname
-    while [[ $ALLOCATED = false ]]; do
-        get_state "$1"
-        [[ $ALLOCATED = true ]] && return
+    while [[ $ALLOCATED != true ]]; do
         sleep 15
+        get_state "$1"
     done
 }
 


### PR DESCRIPTION
Only trust a value of "true", and simplify the loop.
