### PR TITLE
AutoYaST: rubygem-cstruct needs to be installed

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -189,6 +189,7 @@ sync
     <packages config:type="list">
       <package>autoyast2-installation</package>
       <package>biosdevname</package>
+      <package>rubygem-cstruct</package>
       <package>suse-cloud-release</package>
       <package>supportutils-plugin-susecloud</package>
     </packages>


### PR DESCRIPTION
The crowbar ohai plugin depends on rubygem-cstruct nowadays. Installing it as
part of the ohai recipe in the deployer barclamp is not easily possible as that
recipe is also executed inside sle(s|dge)hammer and we can't install packages
at that stage.
