### PR TITLE
controls.sh: Properly exit the outer "control.sh" run

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -20,6 +20,7 @@
 if [[ ! $IN_SCRIPT ]]; then
     export IN_SCRIPT=true
     script -a -f -c "$0" "/install-logs/$HOSTNAME_MAC.transcript"
+    exit $?
 fi
 set -x
 export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '


### PR DESCRIPTION
control.sh re-executes itself with the "script" tool to keep a transcripts of
its run. The outer "control.sh" however is not exited properly after "script"
finshes. Causing it to run the main code a second time under certain
circumstances (e.g. when booting in the "debug" state)
