### PR TITLE
Fix missing constraint for provisioner-bootdisk-finder

### DIFF
--- a/crowbar_framework/app/views/barclamp/provisioner/_edit_deployment.html.haml
+++ b/crowbar_framework/app/views/barclamp/provisioner/_edit_deployment.html.haml
@@ -6,6 +6,7 @@
   $(document).ready(function(){
     var constraints = { 
         "provisioner-server": { "unique": false, "count": 1, "admin":true }, 
+        "provisioner-bootdisk-finder": { "unique": false, "count": -1, "admin":true }, 
         "provisioner-base": { "unique": false, "count": -1, "admin":true } };
     node_selector($('#drag_drop'), constraints);
   });


### PR DESCRIPTION
Otherwise user can't drag available nodes onto that role
