### PR TITLE
Allow SSh access to discovered nodes.

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -74,10 +74,30 @@ node.save if node_modified
 template "/root/.ssh/authorized_keys" do
   owner "root"
   group "root"
-  mode "0700"
+  mode "0644"
   action :create
   source "authorized_keys.erb"
   variables(:keys => node["crowbar"]["ssh"]["access_keys"])
+end
+
+# Also put authorized_keys in tftpboot path on the admin node so that discovered
+# nodes can use the same.
+if node.roles.include? "crowbar"
+  case node[:platform]
+  when "suse"
+    tftpboot_path = "/srv/tftpboot"
+  else
+    tftpboot_path = "/tftpboot"
+  end
+
+  template "#{tftpboot_path}/authorized_keys" do
+    owner "root"
+    group "root"
+    mode "0644"
+    action :create
+    source "authorized_keys.erb"
+    variables(:keys => node["crowbar"]["ssh"]["access_keys"])
+  end
 end
 
 bash "Disable Strict Host Key checking" do

--- a/updates/control.sh
+++ b/updates/control.sh
@@ -75,6 +75,12 @@ if ! grep -q "${ADMIN_IP}" /etc/rsyslog.conf; then
     service $RSYSLOGSERVICE restart
 fi
 
+# enable SSH access from admin node (same keys).
+(umask 077 ; mkdir -p /root/.ssh)
+curl -L -o /root/.ssh/authorized_keys \
+     --connect-timeout 60 -s \
+     "http://$ADMIN_IP:8091/authorized_keys"
+
 MYINDEX=${MYIP##*.}
 DHCP_STATE=$(grep -o -E 'crowbar\.state=[^ ]+' /proc/cmdline)
 DHCP_STATE=${DHCP_STATE#*=}


### PR DESCRIPTION
The provisioner barclamp already allows to specify additional ssh access
keys for the admin node and it makes sense to just reuse those for nodes
that are in discovery state. Helps with debugging and is much easier
than the current solution based on hooks:

  $ cat /updates/discovered-pre/passwd.hook
  PASS="1r21lb1dp1ssw4rd"
  echo -e "$PASS\n$PASS" | passwd

Also, ~/.ssh/authorized_keys mode should be 0644, not 0700.
