### PR TITLE
DE1178: Try to force grub-install to the same device the root filesystem is on. [1/1]

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/net_seed.erb
+++ b/chef/cookbooks/provisioner/templates/default/net_seed.erb
@@ -312,7 +312,7 @@ d-i grub-installer/only_debian boolean true
 # uncomment and edit these lines:
 #d-i grub-installer/only_debian boolean false
 #d-i grub-installer/with_other_os boolean false
-#d-i grub-installer/bootdev  string (hd0,0)
+d-i grub-installer/bootdev string /dev/<%= @boot_device || "sda" %>
 # To install grub to multiple disks:
 #d-i grub-installer/bootdev  string (hd0,0) (hd1,0) (hd2,0)
 


### PR DESCRIPTION
This is a tenative fix against the Mesa 1.6 release for Raajeev to test.

 .../provisioner/templates/default/net_seed.erb     |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 11e9bb24aa636a34d47ed78dcac4e5903509b294

Crowbar-Release: mesa-1.6
