### PR TITLE
Sort keys when creating /root/.ssh/authorized_keys

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/authorized_keys.erb
+++ b/chef/cookbooks/provisioner/templates/default/authorized_keys.erb
@@ -1,3 +1,3 @@
-<% @keys.each do |k,v| -%>
+<% @keys.sort.each do |k,v| -%>
 <%= v %>
 <% end -%>


### PR DESCRIPTION
This will ensure that later chef-client runs won't update the file just
because the order became different.
