### PR TITLE
Run crowbar_join.sh from local source in AutoYaST

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -153,6 +153,8 @@ else
     rm -f /mnt/root/.ssh/authorized_keys.wget
 fi
 
+curl -s -o /mnt/etc/init.d/crowbar_join.sh <%= @crowbar_join %>
+chmod +x /mnt/etc/init.d/crowbar_join.sh
 
 mkdir -p /mnt/var/log/crowbar
 post_state $HOSTNAME "installed"
@@ -167,7 +169,7 @@ sync
     <init-scripts config:type="list">
       <script>
         <filename>crowbar_join</filename>
-        <location><%=@crowbar_join%></location>
+        <location>file:///etc/init.d/crowbar_join.sh</location>
       </script>
     </init-scripts>
   </scripts>


### PR DESCRIPTION
It seems when the network is flaky autoyast tends to
download an empty file then instead. curl while the
network is still up works more reliable.
