### PR TITLE
Turn off debug output in control.sh [1/1]

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -22,7 +22,7 @@ if [[ ! $IN_SCRIPT ]]; then
     script -a -f -c "$0" "/install-logs/$HOSTNAME_MAC.transcript"
     exit $?
 fi
-set -x
+#set -x
 export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
 
 function is_suse {


### PR DESCRIPTION
This pull request turns off debug output in control.sh.

Reference defect DE1312.

 updates/control.sh |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: ffea8bbe0ff2df293bd5c85b70ab151193c03cf8

Crowbar-Release: mesa-1.6
