### PR TITLE
Drop attribute 'root' from bc-template-provisioner.json

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -14,7 +14,12 @@
 #
 
 states = node["provisioner"]["dhcp"]["state_machine"]
-tftproot=node["provisioner"]["root"]
+case node[:platform]
+when "suse"
+  tftproot = "/srv/tftpboot"
+else
+  tftproot = "/tftpboot"
+end
 timezone = (node["provisioner"]["timezone"] rescue "UTC") || "UTC"
 pxecfg_dir="#{tftproot}/discovery/pxelinux.cfg"
 uefi_dir="#{tftproot}/discovery"

--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -38,7 +38,6 @@
          "append": " "
         }
       },
-      "root": "/tftpboot",
       "timezone": "UTC",
       "web_port": 8091,
       "use_local_security": true,

--- a/chef/data_bags/crowbar/bc-template-provisioner.schema
+++ b/chef/data_bags/crowbar/bc-template-provisioner.schema
@@ -18,7 +18,6 @@
             "root_password_hash": { "type": "str" },
             "access_keys": { "type": "str", "required": true },
             "web_port": { "type": "int", "required": true },
-	    "root": { "type": "str", "required": true },
             "timezone": { "type": "str", "required": true },
 	    "default_os": { "type": "str", "required": false },
 	    "supported_oses": {


### PR DESCRIPTION
It was only used in recipes/update_nodes.rb whereas recipes/base.rb used
a node[:platform] check to set the correct tftpboot path. This would
all to drop a hack in SUSE packages.
