### PR TITLE
Add back node["provisioner"]["root"], but not as configurable attribute

### DIFF
--- a/chef/cookbooks/provisioner/attributes/default.rb
+++ b/chef/cookbooks/provisioner/attributes/default.rb
@@ -1,0 +1,6 @@
+case node[:platform]
+when "suse"
+  default[:provisioner][:root] = "/srv/tftpboot"
+else
+  default[:provisioner][:root] = "/tftpboot"
+end

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -14,12 +14,7 @@
 #
 
 states = node["provisioner"]["dhcp"]["state_machine"]
-case node[:platform]
-when "suse"
-  tftproot = "/srv/tftpboot"
-else
-  tftproot = "/tftpboot"
-end
+tftproot=node["provisioner"]["root"]
 timezone = (node["provisioner"]["timezone"] rescue "UTC") || "UTC"
 pxecfg_dir="#{tftproot}/discovery/pxelinux.cfg"
 uefi_dir="#{tftproot}/discovery"


### PR DESCRIPTION
We just put it as an attribute with default value to make it easy to
change the value based on the distribution.
