### PR TITLE
Ignore empty lines in the ssh keys

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -56,6 +56,7 @@ node_modified = true
 # Add additional keys
 node["provisioner"]["access_keys"].strip.split("\n").each do |key|
   key.strip!
+  next if key.empty?
   nodename = key.split(" ")[2]
   nodename = key.split("@")[1] if key.include?("@")
   node.set["crowbar"]["ssh"]["access_keys"][nodename] = key


### PR DESCRIPTION
We were adding empty ssh keys to our list of keys, which just doesn't
work.
