### PR TITLE
Prefer /dev/disk/by-id/scsi-[A-Z] over /dev/disk/by-id/scsi-1*

### DIFF
--- a/chef/cookbooks/provisioner/recipes/bootdisk.rb
+++ b/chef/cookbooks/provisioner/recipes/bootdisk.rb
@@ -27,12 +27,13 @@ ruby_block "Find the fallback boot device" do
     
     basedir="/dev/disk/by-id"
     if File.exists? basedir
-      bootdisks=::Dir.entries(basedir).select do |m|
+      bootdisks=::Dir.entries(basedir).sort.select do |m|
         f="#{basedir}/#{m}"
         File.symlink?(f) && (File.readlink(f).split('/')[-1] == dev)
       end
       unless bootdisks.empty?
-        bootdisk = bootdisks.find{|b|b =~ /^scsi-/} ||
+        bootdisk = bootdisks.find{|b|b =~ /^scsi-[a-zA-Z]/} ||
+          bootdisks.find{|b|b =~ /^scsi-/} ||
           bootdisks.find{|b|b =~ /^ata-/} ||
           bootdisks.first
         node[:crowbar_wall][:boot_device] = "disk/by-id/#{bootdisk}"


### PR DESCRIPTION
The latter seems to be Type1 SCSI compatibility links, which
do not always exist on SLE11 SP3 due to udev bugs.
