### PR TITLE
Explicitly set EDITOR=vi (unset on openSUSE / SLES)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -105,6 +105,11 @@ bash "Disable Strict Host Key checking" do
   not_if "grep -q 'StrictHostKeyChecking no' /etc/ssh/ssh_config"
 end
 
+bash "Set EDITOR=vi environment variable" do
+  code "echo \"EDITOR=vi\" > /etc/profile.d/editor.sh"
+  not_if "export | grep -q EDITOR= ; echo $?"
+end
+
 config_file = "/etc/default/chef-client"
 config_file = "/etc/sysconfig/chef-client" if node[:platform] =~ /^(redhat|centos)$/
 


### PR DESCRIPTION
Primarily this fixes annoying (log) messages from /usr/bin/quantum (due
to cliff/cmd2 usage):

which: no gedit in
(/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/games:/usr/lib/mit/bin:/usr/lib/mit/sbin)
which: no kate in
(/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/games:/usr/lib/mit/bin:/usr/lib/mit/sbin)

Furthermore, this simplifies introspection a bit since those commands
depend on $EDITOR:

```
knife $THING edit $NAME
crowbar $AREA proposal edit $PROPOSAL
```
