### PR TITLE
Allow enabling coredumps.

### DIFF
--- a/chef/cookbooks/provisioner/attributes/default.rb
+++ b/chef/cookbooks/provisioner/attributes/default.rb
@@ -4,3 +4,5 @@ when "suse"
 else
   default[:provisioner][:root] = "/tftpboot"
 end
+
+default[:provisioner][:coredump] = false


### PR DESCRIPTION
Disabled by default, but allow admin to enable for debugging purposes. Core dumps are stored as /tmp/cores/core.%e.%p.%h.%t.

Explicitly not exposed via the UI.
