### PR TITLE
Fix creating /etc/profile.d/editor.sh

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -109,7 +109,7 @@ end
 
 bash "Set EDITOR=vi environment variable" do
   code "echo \"EDITOR=vi\" > /etc/profile.d/editor.sh"
-  not_if "export | grep -q EDITOR= ; echo $?"
+  not_if "export | grep -q EDITOR="
 end
 
 config_file = "/etc/default/chef-client"


### PR DESCRIPTION
The not_if test is broken: we don't need the echo (which will exit with
0), but we need the exit value of grep.
