### PR TITLE
fix AutoYaST bootdevice fallback

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -99,7 +99,9 @@
   </networking>
   <partitioning config:type="list">
     <drive>
-      <device>/dev/<%= @boot_device || "sda" %></device>
+<% if @boot_device %>
+      <device>/dev/<%= @boot_device %></device>
+<% end %>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list"/>
       <type config:type="symbol">CT_DISK</type>


### PR DESCRIPTION
Drop device section if the device is not set.
AutoYaST will decide on its own which device to use in that case.
