### PR TITLE
Put kernel.core_pattern in /etc/sysctl.d/core-dump.conf

### DIFF
--- a/chef/cookbooks/provisioner/files/default/core-dump.conf
+++ b/chef/cookbooks/provisioner/files/default/core-dump.conf
@@ -1,0 +1,1 @@
+kernel.core_pattern = /tmp/cores/core.%e.%p.%h.%t


### PR DESCRIPTION
This avoids manually patching /etc/sysctl.conf.

Note: this depends on https://github.com/crowbar/barclamp-deployer/issues/136
