### PR TITLE
Make coredump attribute available in the proposal

### DIFF
--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -40,6 +40,7 @@
       },
       "timezone": "UTC",
       "web_port": 8091,
+      "coredump": false,
       "use_local_security": true,
       "use_serial_console": false,
       "dhcp": {

--- a/chef/data_bags/crowbar/bc-template-provisioner.schema
+++ b/chef/data_bags/crowbar/bc-template-provisioner.schema
@@ -35,6 +35,7 @@
                 }
               }
             },
+            "coredump": { "type": "bool", "required": true },
             "use_local_security": { "type": "bool", "required": true },
             "use_serial_console": { "type": "bool", "required": true },
             "dhcp": {


### PR DESCRIPTION
We already use this attribute, but there was no way to set it from the
proposal.
