### PR TITLE
Make jigs even more late-bound. [3/5]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -28,20 +28,21 @@ barclamp:
     - network
   member:
     - crowbar
-    
+
 crowbar:
   layout: 2.0
   order: 10
 
-jigs:
-  - name: script
-    roles:
-      - name: provisioner-base
-        requires:
-          - crowbar
-      - name: provisioner-server
-        requires:
-          - provisioner-base
+roles:
+  - name: provisioner-base
+    jig: script
+    requires:
+      - crowbar
+  - name: provisioner-server
+    jig: script
+    requires:
+      - provisioner-base
+
 debs:
   ubuntu-12.04:
     repos:


### PR DESCRIPTION
This pull request series makes jigs even more late bound, and reworks
how roles are defined and loaded from crowbar.yml to make it a
seperate section from the to-be-written jigs section, as the jigs
section should concern itself with declaring what (if any) jigs a
barclamp provides.

 crowbar.yml |   21 +++++++++++----------
 1 file changed, 11 insertions(+), 10 deletions(-)

Crowbar-Pull-ID: b068d7f10391d12115dc134ecb5708d4b046de93

Crowbar-Release: development
