### PR TITLE
reintroduce wait_for_pxe_state to fix node state transistions with slow admin nodes

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -245,11 +245,13 @@ hardware_install () {
     nuke_everything
     walk_node_through $HOSTNAME hardware-installing hardware-installed
     nuke_everything
+    wait_for_pxe_state "os_install"
     walk_node_through $HOSTNAME installing
 }
 
 hwupdate () {
     walk_node_through $HOSTNAME hardware-updating hardware-updated
+    wait_for_pxe_state "execute"
 }
 
 case $DHCP_STATE in

--- a/updates/control_lib.sh
+++ b/updates/control_lib.sh
@@ -118,6 +118,31 @@ wait_for_crowbar_state() {
     done
 }
 
+wait_for_pxe_state() {
+    # $1 = pxe state to wait for.
+
+    # If we've transitioned states, there sometimes needs to be a link for
+    # pxe boot for this MAC address.  Without it, we'll just reboot into
+    # discovery again and get "stuck".  This can happen if the admin node is
+    # very slow updating pxe config.  So just in case we'll poll here for up
+    # to five minutes before giving up and just rebooting
+
+    let pc=0
+    pxe_file="01-$(echo $MAC | tr '[:upper:]:' '[:lower:]-')"
+    pxe_link="http://$ADMIN_IP:8091/discovery/pxelinux.cfg/$pxe_file"
+    pxe_state_link="http://$ADMIN_IP:8091/discovery/pxelinux.cfg/$1"
+
+    while ! diff <(curl -s $pxe_state_link) <(curl -s $pxe_link) > /dev/null; do
+      echo "$pxe_link not found or different from $pxe_state_link. waiting..."
+      sleep 10
+      let pc=pc+1
+      [ $pc -gt 30 ] && {
+        echo "$pxe_link still not found or different. giving up"
+        break
+      }
+   done
+}
+
 report_state () {
     if [ -a /var/log/chef/hw-problem.log ]; then
 	"cp /var/log/chef/hw-problem.log /install-logs/$1-hw-problem.log"


### PR DESCRIPTION
This function was added in the branch release/essex-hack-suse/master.
As the node state transitions break with slow admin nodes, we need to
wait for the next state to be set in the pxe configuration
