### PR TITLE
Reintroduce wait_for_pxe to fix node state transistions with slow admin nodes

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -86,11 +86,14 @@ DHCP_STATE=$(grep -o -E 'crowbar\.state=[^ ]+' /proc/cmdline)
 DHCP_STATE=${DHCP_STATE#*=}
 echo "DHCP_STATE=$DHCP_STATE"
 MAXTRIES=5
+# ADMIN_ADDRESS is the address on the admin network; do not confuse with
+# ADMIN_IP which is the IP of the admin node...
+ADMIN_ADDRESS=""
 BMC_ADDRESS=""
 BMC_NETMASK=""
 BMC_ROUTER=""
 ALLOCATED=false
-export DHCP_STATE MYINDEX BMC_ADDRESS BMC_NETMASK BMC_ROUTER ADMIN_IP
+export DHCP_STATE MYINDEX ADMIN_ADDRESS BMC_ADDRESS BMC_NETMASK BMC_ROUTER ADMIN_IP
 export ALLOCATED HOSTNAME CROWBAR_KEY CROWBAR_STATE
 
 if is_suse; then
@@ -245,7 +248,10 @@ hardware_install () {
     nuke_everything
     walk_node_through $HOSTNAME hardware-installing hardware-installed
     nuke_everything
-    wait_for_pxe_state "install"
+    # We want the os_install state, but its name changes depending on the OS.
+    # For instance: suse-11.3_install. Since no other state end with
+    # "_install", we're good enough with this regexp.
+    wait_for_pxe_state ".*_install"
     walk_node_through $HOSTNAME installing
 }
 

--- a/updates/control_lib.sh
+++ b/updates/control_lib.sh
@@ -6,6 +6,7 @@
 parse_node_data() {
     local res=0
     if node_data=$(/tmp/parse_node_data -a name \
+        -a crowbar.network.admin.address \
         -a crowbar.network.bmc.netmask \
         -a crowbar.network.bmc.address \
         -a crowbar.network.bmc.router \
@@ -18,6 +19,7 @@ parse_node_data() {
                 name) export HOSTNAME=$VAL;;
                 state) export CROWBAR_STATE=$VAL;;
                 crowbar.allocated) export ALLOCATED=$VAL;;
+                crowbar.network.admin.address) export ADMIN_ADDRESS=$VAL;;
                 crowbar.network.bmc.router) export BMC_ROUTER=$VAL;;
                 crowbar.network.bmc.address) export BMC_ADDRESS=$VAL;;
                 crowbar.network.bmc.netmask) export BMC_NETMASK=$VAL;;
@@ -119,36 +121,62 @@ wait_for_crowbar_state() {
 }
 
 
-wait_for_pxe_state() {
-    # $1 = <state>
-    state=$1
+wait_for_pxe() {
+    # $1 = [present|absent]
+    # $2 = <state>
+    mode=$1
+    state=$2
+    [ $mode != "present" ] && state=
 
     # If we've transitioned states, there sometimes needs to be a link for
-    # pxe boot for this MAC address.  Without it, we'll just reboot into
+    # pxe boot for this IP address.  Without it, we'll just reboot into
     # discovery again and get "stuck".  This can happen if the admin node is
     # very slow updating pxe config.  So just in case we'll poll here for up
     # to five minutes before giving up and just rebooting
 
-    # convert MYIP from decimal to hex
-    MYHEXIP=`IFS="." ; for i in $MYIP; do printf '%x' $i | tr 'a-f' 'A-F' ; done`
+    wantedexit=88
+    [ $mode == "present" ] && wantedexit=0
+    [ $mode == "absent" ] && wantedexit=22
+    # 22 is the curl exit code for HTTP status codes of 400 and above
+
+    # convert ADMIN_ADDRESS from decimal to hex
+    MYHEXIP=`IFS="." ; for i in $ADMIN_ADDRESS; do printf '%X' $i ; done`
 
     count=0
     done=0
 
-    echo -n "waiting for pxe file to contain: $state"
-    until [ 1 = $done ] ; do
-        # Note: [^w-] a.s.o. should distinguish between the state "install" and states that contain the string "install"
-        curl --fail --silent --head --connect-timeout 5 "http://$ADMIN_IP:8091/discovery/pxelinux.cfg/$MYHEXIP" | grep -E "DEFAULT.*[^w-]install($|[^ei])"
-        ret=$?
+    if [ -n "$state" ]; then
+        echo -n "waiting for pxe file to contain: $state "
+    else
+        echo -n "waiting for pxe file to be: $mode "
+    fi
 
-        if [ 0 = $ret ] ; then
-            echo "pxe file contains now: $state"
+    until [ 1 = $done ] ; do
+        if [ -n "$state" ]; then
+            curl --fail --silent --connect-timeout 5 "http://$ADMIN_IP:8091/discovery/pxelinux.cfg/$MYHEXIP" | grep -q "^DEFAULT $state$"
+            ret=$?
+        else
+            curl --fail --silent --head --connect-timeout 5 "http://$ADMIN_IP:8091/discovery/pxelinux.cfg/$MYHEXIP" > /dev/null
+            ret=$?
+        fi
+
+        if [ $wantedexit = $ret ] ; then
+            if [ -n "$state" ]; then
+                echo "pxe file now contains: $state"
+            else
+                echo "pxe file is now: $mode"
+            fi
             done=1
+            break
         else
             echo -n "."
             let count=count+1
             [ $count -gt 30 ] && {
-                echo "Warning: pxe file still contains $state. giving up."
+                if [ -n "$state" ]; then
+                    echo "Warning: pxe file still contains $state. giving up."
+                else
+                    echo "Warning: pxe file still not $mode. giving up."
+                fi
                 break
             }
             sleep 10
@@ -157,45 +185,15 @@ wait_for_pxe_state() {
 }
 
 
+wait_for_pxe_state() {
+    # $1 = <state>
+    wait_for_pxe "present" "$1"
+}
+
+
 wait_for_pxe_file() {
     # $1 = [present|absent]
-    mode=$1
-
-    # If we've transitioned states, there sometimes needs to be a link for
-    # pxe boot for this MAC address.  Without it, we'll just reboot into
-    # discovery again and get "stuck".  This can happen if the admin node is
-    # very slow updating pxe config.  So just in case we'll poll here for up
-    # to five minutes before giving up and just rebooting
-
-    wantedexit=88
-    [ $mode = "present" ] && wantedexit=0
-    [ $mode = "absent" ] && wantedexit=22
-    # 22 is the curl exit code for HTTP status codes of 400 and above
-
-    # convert MYIP from decimal to hex
-    MYHEXIP=`IFS="." ; for i in $MYIP; do printf '%x' $i | tr 'a-f' 'A-F' ; done`
-
-    count=0
-    done=0
-
-    echo -n "waiting for pxe file to be: $mode"
-    until [ 1 = $done ] ; do
-        curl --fail --silent --head --connect-timeout 5 "http://$ADMIN_IP:8091/discovery/pxelinux.cfg/$MYHEXIP" > /dev/null
-        ret=$?
-
-        if [ $wantedexit = $ret ] ; then
-            echo "pxe file is now: $mode"
-            done=1
-        else
-            echo -n "."
-            let count=count+1
-            [ $count -gt 30 ] && {
-                echo "Warning: pxe file still not $mode. giving up."
-                break
-            }
-            sleep 10
-        fi
-    done
+    wait_for_pxe "$1" ""
 }
 
 


### PR DESCRIPTION
This is the fixed version of https://github.com/crowbar/barclamp-provisioner/pull/173
