### PR TITLE
Use /var/log/crowbar/sledgehammer instead of /install-logs [1/2]

### DIFF
--- a/chef/cookbooks/nfs-server/recipes/default.rb
+++ b/chef/cookbooks/nfs-server/recipes/default.rb
@@ -56,7 +56,7 @@ service rpcService do
   action [ :enable, :start ]
 end
 
-directory "/install-logs" do
+directory "/var/log/crowbar/sledgehammer" do
   owner "root"
   group "root"
   mode 0755

--- a/chef/cookbooks/nfs-server/templates/default/exports.erb
+++ b/chef/cookbooks/nfs-server/templates/default/exports.erb
@@ -1,3 +1,3 @@
-/install-logs     <%= @admin_subnet %>/<%= @admin_netmask %>(rw,async,no_root_squash,no_subtree_check)
+/var/log/crowbar/sledgehammer     <%= @admin_subnet %>/<%= @admin_netmask %>(rw,async,no_root_squash,no_subtree_check)
 /updates     <%= @admin_subnet %>/<%= @admin_netmask %>(ro,sync,no_subtree_check)
 

--- a/updates/control.sh
+++ b/updates/control.sh
@@ -19,7 +19,7 @@
 
 if [[ ! $IN_SCRIPT ]]; then
     export IN_SCRIPT=true
-    script -a -f -c "$0" "/install-logs/$HOSTNAME_MAC.transcript"
+    script -a -f -c "$0" "/var/log/crowbar/sledgehammer/$HOSTNAME_MAC.transcript"
     exit $?
 fi
 #set -x
@@ -256,6 +256,6 @@ case $DHCP_STATE in
     reset|discovery) discover && hardware_install;;
     hwinstall) hardware_install;;
     update) hwupdate;;
-esac 2>&1 | tee -a /install-logs/$HOSTNAME-update.log
+esac 2>&1 | tee -a /var/log/crowbar/sledgehammer/$HOSTNAME.log
 [[ $DHCP_STATE = 'debug' ]] && exit
 reboot_system

--- a/updates/control_lib.sh
+++ b/updates/control_lib.sh
@@ -80,7 +80,7 @@ get_state() { try_to "$MAXTRIES" 15 __get_state "$@"; }
 reboot_system() {
   sync
   sleep 30
-  umount -l /updates /install-logs
+  umount -l /updates /var/log/crowbar/sledgehammer
   reboot -f
 }
 
@@ -93,7 +93,7 @@ wait_for_allocated() {
 }
 
 hook_has_run() {
-    local statefile="/install-logs/$HOSTNAME-$HOOKNAME-$HOOKSTATE"
+    local statefile="/var/log/crowbar/sledgehammer/$HOSTNAME-$HOOKNAME-$HOOKSTATE"
     if [[ -f $statefile ]]; then
         return 0
     else
@@ -120,7 +120,7 @@ wait_for_crowbar_state() {
 
 report_state () {
     if [ -a /var/log/chef/hw-problem.log ]; then
-	"cp /var/log/chef/hw-problem.log /install-logs/$1-hw-problem.log"
+	"cp /var/log/chef/hw-problem.log /var/log/crowbar/sledgehammer/$1-hw-problem.log"
         post_state "$1" problem
     else
         post_state "$1" "$2"


### PR DESCRIPTION
This is a come-back of an old commit.

Note that this depends on https://github.com/crowbar/crowbar/pull/1891

Crowbar-Pull-ID: 6dc60e5906b8eb9abe8b14cdbefea73a78ce6f4c

Crowbar-Release: pebbles
