### PR TITLE
Start refactoring network barclamp to add per-network roles. [2/4]

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -26,7 +26,6 @@ uefi_dir=discover_dir
 pxecfg_default="#{pxecfg_dir}/default"
 nodes = search(:node, "*:*")
 Chef::Log.info("Node ount = #{nodes.length}")
-admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
 if not nodes.nil? and not nodes.empty?
   nodes.map{|n|Node.load(n.name)}.each do |mnode|
     Chef::Log.info("Testing if #{mnode[:fqdn]} needs a state transition")


### PR DESCRIPTION
This pull request series starts the work of making network definition
and usage dynamic by representing networks as roles, and IP/interface
allocations to a node as noderoles.

I also started throwing away more code we do not need.

 chef/cookbooks/provisioner/recipes/update_nodes.rb |    1 -
 1 file changed, 1 deletion(-)

Crowbar-Pull-ID: cf6cf08bb7869606011fdde39fb5680b75dc0997

Crowbar-Release: development
