### PR TITLE
CB 2.0: Make the network barclamp really work, and make all the recipes really Chef11 compliant. [3/5]

### DIFF
--- a/chef/cookbooks/dhcp/resources/subnet.rb
+++ b/chef/cookbooks/dhcp/resources/subnet.rb
@@ -17,7 +17,7 @@ actions :add, :remove
 
 attribute :subnet, :kind_of => String, :name_attribute => true
 attribute :network, :kind_of => Mash
-attribute :pools, :kind_of => Array, :default => [ "dhcp" ]
+attribute :pools, :kind_of => Array
 attribute :pool_options, :kind_of => Hash, :default => { "dhcp" => [ "allow unknown-hosts" ] }
 attribute :options, :kind_of => Array, :default => []
 

--- a/chef/cookbooks/dhcp/templates/default/subnet.conf.erb
+++ b/chef/cookbooks/dhcp/templates/default/subnet.conf.erb
@@ -1,7 +1,7 @@
 # File managed by Crowbar
 subnet <%= @addr.addr -%> netmask <%= @addr.netmask %> {
 <% if @network["router"] -%>
-  option routers <%= @network["router"] %>;
+  option routers <%= @network["router"]["address"].addr %>;
 <% end -%>
   option subnet-mask <%= @addr.netmask %>;
   option broadcast-address <%= @addr.broadcast.addr %>;
@@ -10,10 +10,10 @@ subnet <%= @addr.addr -%> netmask <%= @addr.netmask %> {
 <%   end -%>
 <% @pools.each do |pool| -%>
    pool {
-     range <%=@network["ranges"][pool]["start"]%> <%=@network["ranges"][pool]["end"]%>;
-     <% @pool_options[pool].each do |opt| -%>
+     range <%=IP.coerce(pool["first"]).addr%> <%=IP.coerce(pool["last"]).addr%>;
+     <% @pool_options[pool["name"]].each do |opt| -%>
      <%=opt%><%=if opt[-1,1] != '}' then ';' else '' end%>
-     <% end if @pool_options[pool] -%>
+     <% end if @pool_options[pool["name"]] -%>
    }
 <% end -%>
 }


### PR DESCRIPTION
This pull request series makes the network barclamp interact with the
core Crowbar framework allow for:
- Dynamic creation of networks at point of need rather than having to
  set them all up ahead of time.
- Presenting networks as roles to the core Crowbar framework.
- Presenting address and network interface allocations as noderoles.

Since this is a first-pass implementation, it lacks a few amenities:
- Networks cannot be edited after they are created.  This will be
  addressed once we get a good idea about what sorts of edits to a
  network make sense in a running cluster, and how to make edits on a
  live cluster with a decent stab at not losing overall connectivity.
- Address allocations can not be deleted once created.  This will be
  enabled once we have a better idea about how to do so in a way that
  does not break the node-role graph.
- The network barclamp only knows how to present information to the
  core, it has no idea how to get information back.
- The admin network is special, and that specialness is hardcoded.  It
  should be driven by configuration metadata from the network-server
  role instead.

This also fixes up a series of non-Chef 11 compliant recipes due to a
combination of bad cache hygene on my part and the Chef 10 client
imnitruck installer having an inexplicably higher priority than the
Chef 11 one.

 chef/cookbooks/dhcp/resources/subnet.rb            |    2 +-
 .../dhcp/templates/default/subnet.conf.erb         |    8 +-
 chef/cookbooks/provisioner/recipes/dhcp_update.rb  |    7 +-
 .../provisioner/recipes/setup_base_images.rb       |  118 +++++++++++---------
 4 files changed, 76 insertions(+), 59 deletions(-)

Crowbar-Pull-ID: 402e9ce91111702c1f810a6a19545ee4d489a3f9

Crowbar-Release: development
