### PR TITLE
Add tighter control over how jig runs are queued on a per-node basis, and rework the DNS barclamp to use the new runs infrastructure. [2/4]

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/control.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/control.sh.erb
@@ -80,7 +80,35 @@ for net in "${nets[@]}"; do
     net=${BASH_REMATCH[1]}
     # Make this more complicated and exact later.
     ip addr add "$net" dev "$BOOTDEV" || :
-    echo "${net%/*} $FQDN" >> /etc/hosts
+done
+
+# Figure out what IP addresses the admin node has
+netline=$(curl -g --digest -u "$CROWBAR_KEY" \
+    -X GET "$crowbar_v4/network/api/v2/networks/admin/allocations" \
+    -d "node=<%=@provisioner_name%>")
+
+# Update our /etc/resolv.conf with the IP address of our admin node,
+# which is assumed to be our nameserver
+chattr -i /etc/resolv.conf || :
+echo "domain $DOMAIN" >/etc/resolv.conf.new
+
+nets=(${netline//,/ })
+for net in "${nets[@]}"; do
+    [[ $net =~ $ip_re ]] || continue
+    net=${BASH_REMATCH[1]}
+    echo "nameserver ${net%%/*}" >> /etc/resolv.conf.new
+done
+
+mv -f /etc/resolv.conf.new /etc/resolv.conf
+chattr +i /etc/resolv.conf
+
+# Force reliance on DNS
+echo '127.0.0.1 localhost' >/etc/hosts
+echo '::1 localhost6' >>/etc/hosts
+
+# Wait for the DNS server to notice that we are alive.
+while ! ping6 -c 1 -w 1 "$HOSTNAME"; do
+    sleep 1
 done
 
 # Synchronize our date


### PR DESCRIPTION
This pull request adds a few new features:
- Move most of the annealing responsibilites to a newly-created Run
  class.  This allows to to more easily enforce our one jig run at a
  time per node rule, and gives us a nicer place to control what kind
  of parallelism we use.
- Fix up the DNS barclamp to use the new Run infrastructure and the
  on_node_\* hooks to manage our DNS infrastructure.  This will also
  act as a template for similar changes needed for the DHCP
  infrastructure.
- Minor update to the provisioner barclamp to handle bringing up the
  node properly in the face of the Runs and DNS barclamp changes.
  
  .../provisioner/templates/default/control.sh.erb   | 30 +++++++++++++++++++++-
  1 file changed, 29 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: b8895885003093f140e37ed4f5efc36a05f38852

Crowbar-Release: development
