### PR TITLE
Have control.sh mark the node as dead on reboot if Crowbar knows about the node. [1/1]

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/control.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/control.sh.erb
@@ -57,6 +57,12 @@ if [[ $NEED_CREATE ]]; then
     curl -g --digest -u "$CROWBAR_KEY" -X POST \
         -d "name=$HOSTNAME" \
         "$crowbar_v4/api/v2/nodes/"
+else
+    # We know who we should be, but we are coming back to life.
+    # Mark us as dead to let our role resynchronize.
+    curl -g --digest -u "$CROWBAR_KEY" \
+        -X PUT "$crowbar_v4/api/v2/nodes/$HOSTNAME" \
+        -d 'alive=false'
 fi
 
 # Ditch NFS for now.


### PR DESCRIPTION
This allows the Crowbar framework to rerun all the noderoles bound to the node on node reboot while in Sledgehammer.

 chef/cookbooks/provisioner/templates/default/control.sh.erb | 6 ++++++
 1 file changed, 6 insertions(+)

Crowbar-Pull-ID: 5988cf34242eb16d561eaae29f7a0bdb6865e5bf

Crowbar-Release: development
