### PR TITLE
Fix DHCP IP address assignment when multiple nics are present [1/1]

### DIFF
--- a/chef/cookbooks/dhcp/templates/default/host.conf.erb
+++ b/chef/cookbooks/dhcp/templates/default/host.conf.erb
@@ -1,7 +1,11 @@
 host <%= @name %> {
   option host-name "<%= @hostname %>";
   hardware ethernet <%= @macaddress %>;
+<% if @ipaddress -%> 
   fixed-address <%= @ipaddress %>;
+<% else -%>
+  deny booting;
+<% end -%> 
 <% if not @options.empty? -%>
 <%   @options.each do |option| -%>
   <%= option %><%=if option[-1,1] != '}' then ';' else '' end%>

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -77,7 +77,9 @@ if not nodes.nil? and not nodes.empty?
       mac_list.each_index do |i|
         dhcp_host "#{mnode.name}-#{i}" do
           hostname mnode.name
-          ipaddress admin_data_net.address
+          if mnode.macaddress == mac_list[i]
+            ipaddress admin_data_net.address
+          end
           macaddress mac_list[i]
           action :add
         end
@@ -92,20 +94,22 @@ if not nodes.nil? and not nodes.empty?
       mac_list.each_index do |i|
         dhcp_host "#{mnode.name}-#{i}" do
           hostname mnode.name
-          ipaddress admin_data_net.address
           macaddress mac_list[i]
-          options [
-   '      if option arch = 00:06 {
-      filename = "discovery/bootia32.efi";
-   } else if option arch = 00:07 {
-      filename = "discovery/bootx64.efi";
-   } else if option arch = 00:09 {
-      filename = "discovery/bootx64.efi";
-   } else {
-      filename = "discovery/pxelinux.0";
-   }',
-                   "next-server #{admin_ip}"
-                  ]
+          if mnode.macaddress == mac_list[i]
+            ipaddress admin_data_net.address
+            options [
+     '      if option arch = 00:06 {
+        filename = "discovery/bootia32.efi";
+     } else if option arch = 00:07 {
+        filename = "discovery/bootx64.efi";
+     } else if option arch = 00:09 {
+        filename = "discovery/bootx64.efi";
+     } else {
+        filename = "discovery/pxelinux.0";
+     }',
+                     "next-server #{admin_ip}"
+                    ]
+          end
           action :add
         end
       end


### PR DESCRIPTION
When multiple ethernet adapters are present, a host file is created in /etc/dhcp3/hosts.d/ for each interface. All these files contain the same IP address (node management address).
- Added condition in update_nodes.rb to set IP address only for the boot interface
- Added condition in dhcp template to deny boot if no IP is set (see update_nodes.rb)

On Windows nodes we rely on DHCP for IP address assignment, as opposed to Linux where the IP address is set statically uppon installation. Assigning the same IP address for all interfaces leads to unpredictable behavior between reboots. The IP address is assigned to the first interface that completes the DHCP handshake, and we rely on the interface for a series of checks.

 .../cookbooks/dhcp/templates/default/host.conf.erb |    4 +++
 chef/cookbooks/provisioner/recipes/update_nodes.rb |   32 +++++++++++---------
 2 files changed, 22 insertions(+), 14 deletions(-)

Crowbar-Pull-ID: a753d22fc919b2fbf2464394bfac35589e6ab997

Crowbar-Release: pebbles
