### PR TITLE
Fixups to network and provisioner in CB 2.0 [3/3]

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/control.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/control.sh.erb
@@ -147,8 +147,11 @@ gem install cstruct
 
 mkdir -p /root/.ssh
 cat >/root/.ssh/authorized_keys <<EOF
-<% @keys %>
+<%= @keys %>
 EOF
+
+echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config
+service sshd restart
 
 # Mark us as alive.
 # Mark the node as alive.


### PR DESCRIPTION
These actually make v6prefix actually function for the admin network, and actually injects our SSH stuff into the system.

 chef/cookbooks/provisioner/templates/default/control.sh.erb | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: b270781498ad8e7eff7e1b087b76903f225e98ee

Crowbar-Release: development
