### PR TITLE
Fix start order

### DIFF
--- a/chef/cookbooks/provisioner/files/default/crowbar_join.init.suse
+++ b/chef/cookbooks/provisioner/files/default/crowbar_join.init.suse
@@ -2,7 +2,7 @@
 ### BEGIN INIT INFO
 # Provides:          crowbar
 # Required-Start:    $syslog $network $remote_fs sshd
-# Should-Start:      
+# Should-Start:      openstack-keystone openstack-quantum
 # Required-Stop:     $syslog $network $remote_fs sshd
 # Should-Stop:       
 # Default-Start:     3 5
@@ -13,6 +13,12 @@
 
 # Note: the sshd dependency is there to make it possible to log in while
 # crowbar_join is running (in case it's hanging).
+# - the optional openstack-keystone dependency is there so that the calls to
+#   keystone APIs in cookbooks work (if we're running on controller node)
+#   Otherwise, the chef-client run will fail there (because keystone is started
+#   delayed in the cookbook)
+# - similarly, the quantum cookbook will contact the quantum APIs so we need an
+#   optional openstack-quantum dependency.
 
 PROGNAME="crowbar_join"
 


### PR DESCRIPTION
crowbar_join wants keystone and quantum, so start after it
(if running on the same host).
