### PR TITLE
Add openstack-{keystone,neutron} Should-Start in SUSE init script for crowbar_join

### DIFF
--- a/chef/cookbooks/provisioner/files/default/crowbar_join.init.suse
+++ b/chef/cookbooks/provisioner/files/default/crowbar_join.init.suse
@@ -2,7 +2,7 @@
 ### BEGIN INIT INFO
 # Provides:          crowbar
 # Required-Start:    $syslog $network $remote_fs sshd
-# Should-Start:      openstack-keystone
+# Should-Start:      openstack-keystone openstack-neutron
 # Required-Stop:     $syslog $network $remote_fs sshd
 # Should-Stop:       
 # Default-Start:     3 5
@@ -18,6 +18,8 @@
 #   keystone APIs in cookbooks work (if we're running on controller node)
 #   Otherwise, the chef-client run will fail there (because keystone is started
 #   delayed in the cookbook)
+# - similarly, the neutron cookbook will contact the neutron APIs so we need an
+#   optional openstack-neutron dependency.
 
 PROGNAME="crowbar_join"
 


### PR DESCRIPTION
crowbar_join will call chef-client; if this is happening on a controller
node, then the server roles for glance/cinder/quantum/nova will try to
contact the keystone API. But this one won't have started yet since the
keystone cookbook will only restart it delayed (unless the config file
changed, which won't happen on boot).

So we need to have keystone running before. Same thing for neutron.
