### PR TITLE
Pull in proper packages for OpenSUSE 12.3 [3/4]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -68,8 +68,6 @@ roles:
 
 debs:
   ubuntu-12.04:
-    repos:
-      - deb http://ppa.launchpad.net/nginx/stable/ubuntu oneiric main
     pkgs:
       - rpcbind
   pkgs:
@@ -79,61 +77,75 @@ debs:
     - ipmitool
     - syslinux
     - tftpd-hpa
-    - nginx-light
     - efibootmgr
+    # apache stuff
+    - apache2
+    - apache2-prefork-dev
+    - libapache2-mod-fcgid
+    - libapache2-mod-wsgi
   build_pkgs:
     - build-essential
     - make
-
 rpms:
-  redhat-5.6:
-    repos:
-      - bare nginx 10 http://nginx.org/packages/rhel/5/x86_64/
-    pkgs:
-      - portmap
-      - OpenIPMI-tools
-  redhat-5.7:
-    repos:
-      - bare nginx 10 http://nginx.org/packages/rhel/5/x86_64/
-    pkgs:
-      - portmap
-      - OpenIPMI-tools
-  centos-5.7:
-    repos:
-      - bare nginx 10 http://nginx.org/packages/rhel/5/x86_64/
-    pkgs:
-      - portmap
-      - OpenIPMI-tools
-  redhat-6.2:
-    repos:
-      - bare nginx 10 http://nginx.org/packages/rhel/6/x86_64/
+  redhat-6.4:
     pkgs:
       - rpcbind
       - ipmitool
+      - dhclient
+      - nfs-utils
+      - tftp-server
+      # apache stuff
+      - httpd
+      - httpd-devel
+      - mod_fcgid
+      - mod_ssl
+      - mod_wsgi
     build_pkgs:
       - tar
-  centos-6.2:
-    repos:
-      - bare nginx 10 http://nginx.org/packages/rhel/6/x86_64/
+  centos-6.4:
     pkgs:
       - rpcbind
       - ipmitool
+      - dhclient
+      - nfs-utils
+      - tftp-server
+      # apache stuff
+      - httpd
+      - httpd-devel
+      - mod_fcgid
+      - mod_ssl
+      - mod_wsgi
+
     build_pkgs:
       - tar
   fedora-18:
     pkgs:
       - rpcbind
       - ipmitool
+      - dhclient
+      - nfs-utils
+      - tftp-server
+      # apache stuff
+      - httpd
+      - httpd-devel
+      - mod_fcgid
+      - mod_ssl
+      - mod_wsgi
+
     build_pkgs:
       - tar
+  opensuse-12.3:
+    pkgs:
+      - nfs-client
+      - nfs-kernel-server
+      - dhcp-client
+      - tftp
+      - apache2
+      - apache2-devel
   pkgs:
     - dhcp
-    - dhclient
-    - nfs-utils
     - syslinux
-    - tftp-server
     - xinetd
-    - nginx
     - efibootmgr
   build_pkgs:
     - flex


### PR DESCRIPTION
This pull request allows the build process to pull in all the packages
opensuse 12.3 should need to allow a Crowbar admin node to bootstrap
itself.

At this point, we still cannot bring up a fully-functional CB 2.0 node
on Opensuse due to the lack of a working Chef 11 Server -- the
omniinstall version for RHEL does not work due to systemd, and I have
not tried the natively packaged version.

 crowbar.yml | 76 +++++++++++++++++++++++++++++++++++--------------------------
 1 file changed, 44 insertions(+), 32 deletions(-)

Crowbar-Pull-ID: 6c0b42217dd2877ca92d408c68dc8c8d57bd5cd8

Crowbar-Release: development
