### PR TITLE
use the full ssh comment as key

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -66,7 +66,6 @@ node["provisioner"]["access_keys"].strip.split("\n").each do |key|
   key.strip!
   if !key.empty?
     nodename = key.split(" ")[2]
-    nodename = key.split("@")[1] if key.include?("@")
     node.set["crowbar"]["ssh"]["access_keys"][nodename] = key
   end
 end


### PR DESCRIPTION
Otherwise, if several keys with the same hostname (a@foo.com, b@foo.com)
are used, only the last is stored.
