### PR TITLE
Improve workflow for simulated nodes and add node.hint for future function [2/2]

### DIFF
--- a/crowbar_engine/barclamp_provisioner/app/models/barclamp_provisioner/os_install.rb
+++ b/crowbar_engine/barclamp_provisioner/app/models/barclamp_provisioner/os_install.rb
@@ -26,12 +26,12 @@ class BarclampProvisioner::OsInstall < Role
   def on_transition(nr)
     node = nr.node
     target = nr.all_my_data["crowbar"]["target_os"] rescue nr.deployment_data["crowbar"]["target_os"]
-    return if node.bootenv == "local"
+    return if ["local"].member? node.bootenv
     Rails.logger.info("provisioner-install: Trying to install #{target} on #{node.name} (bootenv: #{node.bootenv})")
 
     node.bootenv = "#{target}-install"
     # for most jigs we want force the node to check back in.  Since the 
-    node.alive = false unless nr.role.jig_name.eql? 'test'
+    node.alive = false
     node.save!
   end
 

--- a/crowbar_engine/barclamp_provisioner/app/models/barclamp_provisioner/server.rb
+++ b/crowbar_engine/barclamp_provisioner/app/models/barclamp_provisioner/server.rb
@@ -15,14 +15,30 @@
 
 class BarclampProvisioner::Server < Role
 
+  KEY_FILE = "/etc/crowbar.install.key"
+
+  # when proposed, we need to create an entry for crowbar's admin key
   def on_proposed(nr)
+
+    # the key should exist, we need to handle deal with cases where it does not
+    key = if File.exist? KEY_FILE
+      File.read(KEY_FILE).chomp.strip
+    elsif Jig.active('test')
+      "testing_no_key_required"
+    else
+      Rails.logger.error "Provisioner Server Role requires the Crowbar Key from '#{KEY_FILE}' but could not find it"
+      raise "Proviser Server Role cannot find #{KEY_FILE}"
+    end
+
+    # build the JSON data for the node role
     nr.sysdata = {
       "crowbar" => {
         "provisioner" => {
-          "machine_key" => File.read("/etc/crowbar.install.key").chomp.strip
+          "machine_key" => key
         }
       }
     }
+    
   end
 
 end


### PR DESCRIPTION
1) Improve the way that we handle simulated machines (prep for Docker) so that we skip the 
provisioner logic more naturally.  The original code used the Jig.active(test) check while 
the new approach requires that the simulator (or Docker or node adder) use the "noop" Bootenv
to tell Crowbar to skip provisioning.

  1a) Expose bootenv on the UI

2) Fix issue where provisioner looks for Crowbar key that is not present in test mode 
does not cause failures.  If it's missing in production mode then raise a better error

3) Add node.hint field into the database.  This is WIP for allowing users to make requests for
Crowbar to implement during operations (already updated in the docs).

TO DO ITEMS:
1) test bootenv in BDD (may add to this pull)
2) continue to work on hint

 .../app/models/barclamp_provisioner/os_install.rb  |    4 ++--
 .../app/models/barclamp_provisioner/server.rb      |   18 +++++++++++++++++-
 2 files changed, 19 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: f6953a47db518d6a0bd0831843a23ccde9340576

Crowbar-Release: development
