### PR TITLE
Add support for non-idempotent roles. [2/3]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -65,6 +65,7 @@ roles:
       - provisioner-dhcp-server
     flags:
       - implicit
+      - destructive
 
 debs:
   ubuntu-12.04:


### PR DESCRIPTION
This pull request series adds support for:
- Declaring that a role is non-idempotent, which will tell the
  annealer that noderoles for that role should not be rerun after it
  has sucessfully transitioned to active.
- Rebooting a node, putting a node into debug mode, and pulling it out
  of debug mode via the API and CLI interfaces.
  
  crowbar.yml | 1 +
  1 file changed, 1 insertion(+)

Crowbar-Pull-ID: 711cb679ae93eb9648f168e599dceeeb06524c9a

Crowbar-Release: development
