### PR TITLE
Node.hint allows you to request IP (and other attributes) when Node is created in API [3/3]

### DIFF
--- a/crowbar_engine/barclamp_provisioner/app/models/barclamp_provisioner/os_install.rb
+++ b/crowbar_engine/barclamp_provisioner/app/models/barclamp_provisioner/os_install.rb
@@ -26,6 +26,8 @@ class BarclampProvisioner::OsInstall < Role
   def on_transition(nr)
     node = nr.node
     target = nr.all_my_data["crowbar"]["target_os"] rescue nr.deployment_data["crowbar"]["target_os"]
+    # this could be expanded if needed but "local" can be used for any overrides including simulator & docker vms
+    # local means, skip sledgehammer and use the installed OS
     return if ["local"].member? node.bootenv
     Rails.logger.info("provisioner-install: Trying to install #{target} on #{node.name} (bootenv: #{node.bootenv})")
 


### PR DESCRIPTION
I added this for working with Docker where we cannot set the IP; however, the implementation of hint enables some
really awesome capabilities (not implemented, but now possible).  I have choosen to narrowly implement only the IP 
feature.

This pull includes BOTH docs and bdd tests for this capability in crowbar & network!

The first part in the crowbar framework is to add .hint to nodes and expose this in the API.  I added a helper for the most common usecase - requesting an admin network IP address.

The second part is to have the network role handler use the hint when it allocates the network IP address.  
The allocation part already had logic for suggesting an IP that we were not using until now.  In this case, I simply use the hint to pass in the optional suggestion parameter.

Overall, a very surgical change for a major feature addition.

In the future, hinting can be used to allow users to request operating system, MAC-Name maps, RAID configs and even workloads when a node is created.  
The pattern for this is to add a category for the role doing the operations (e.g.: provisioner-os-installed) and then a key-value pair that the role
would implment ("os=>OpenSuse-13.1") or similar.  

For the MAC-Name mapping, the deployer would use the hint to pre-create the DHCP entry.

 .../app/models/barclamp_provisioner/os_install.rb  |    2 ++
 1 file changed, 2 insertions(+)

Crowbar-Pull-ID: 5a75eba6eb8ed557dfb21f1c50c4eef5c4188bcd

Crowbar-Release: development
