### PR TITLE
Make role attributes work, and add some to play around with in CB 2.0 [3/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -43,6 +43,34 @@ roles:
       - ntp-server
     flags:
       - server
+    attribs:
+      - name: provisioner-machine_key
+        description: 'The username and password that managed nodes should use to talk to the Crowbar API'
+        map: 'crowbar/provisioner/machine_key'
+      - name: provisioner-access_keys
+        description: 'The SSH public keys that should allow passwordless root access on managed nodes.'
+        map: 'crowbar/provisioner/server/access_keys'
+      - name: provisioner-name
+        description: 'The DNS name of the provisioner server.'
+        map: 'crowbar/provisioner/server/name'
+      - name: provisioner-v4addr
+        description: 'The IPv4 address of the provisioner server'
+        map: 'crowbar/provisioner/server/v4addr'
+      - name: provisioner-v6addr
+        description: 'The IPv6 address of the provisioner server'
+        map: 'crowbar/provisioner/server/v6addr'
+      - name: provisioner-proxy
+        description: 'The caching HTTP proxy that managed nodes should use'
+        map: 'crowbar/provisioner/server/proxy'
+      - name: provisioner-webserver
+        description: 'The URL that managed nodes should use to contact the provisioner webserver.'
+        map: 'crowbar/provisioner/server/webserver'
+      - name: provisioner-package-repos
+        description: 'The packages repositories that managed nodes should use to install packages.'
+        map: 'crowbar/provisioner/server/repositories'
+      - name: provisioner-available-oses
+        description: 'The operating systems that the provisioner knows how to install'
+        map: 'crowbar/provisioner/server/available_oses'
   - name: provisioner-repos
     jig: chef-solo
     requires:
@@ -51,6 +79,8 @@ roles:
       - provisioner-server
     flags:
       - implicit
+    wants-attribs:
+      - provisioner-package-repos
   - name: provisioner-dhcp-server
     jig: chef-solo
     requires:
@@ -66,7 +96,10 @@ roles:
     flags:
       - implicit
       - destructive
-
+    attribs:
+      - name: provisioner-target_os
+        description: "The operating system to install on a node"
+        map: 'crowbar/target_os'
 debs:
   ubuntu-12.04:
     pkgs:


### PR DESCRIPTION
- Make Attrib.get smart. Instead of passing a blob of JSON, it now
  accepts the object it should try to work with. This centralizes the
  logic around what fields in an object are valid places to get
  attributes from, and will fail hard if you pass it something that
  should not work with the attribute system.
- Add matching Attrib.set methods. This provides an abstract interface
  for setting attributes on objects that matches the use of
  Attrib.get.
- Add some attributes to various nodes to lay the groundwork for
  adding logic to the annealer to make it consiter attribute visibility.
- Numerous trivial cleanups to make things work with the above changes.
  
  crowbar.yml | 35 ++++++++++++++++++++++++++++++++++-
  1 file changed, 34 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: cd953079fcc42015c6552d4b6d190cc54e898308

Crowbar-Release: development
