### PR TITLE
CB 2: Make all the things use wants-attrib for smart attribute injection. [3/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -41,12 +41,13 @@ roles:
       - dns-client
       - logging-server
       - ntp-server
-    flags:
-      - server
     attribs:
       - name: provisioner-machine_key
         description: 'The username and password that managed nodes should use to talk to the Crowbar API'
         map: 'crowbar/provisioner/machine_key'
+      - name: provisioner-server-data
+        description: 'Unified blob of all the provisioner server data'
+        map: 'crowbar/provisioner/server'
       - name: provisioner-access_keys
         description: 'The SSH public keys that should allow passwordless root access on managed nodes.'
         map: 'crowbar/provisioner/server/access_keys'
@@ -84,18 +85,33 @@ roles:
         description: 'Hint for Admin MAC address'
         map: 'admin_mac'
     wants-attribs:
-      - name: provisioner-package-repos
-        at: 'crowbar/provisioner/server/repositories'
+      - provisioner-package-repos
   - name: provisioner-dhcp-server
     jig: chef-solo
+    wants-attribs:
+      - provisioner-v4addr
+      - dns_all_data
+      - network-admin
     requires:
       - provisioner-server
+    attribs:
+      - name: provisioner-dhcp-data
+        description: 'All of the provisioner DHCP database information'
+        map: 'crowbar/dhcp'
   - name: provisioner-dhcp-database
     jig: chef-solo
+    wants-attribs:
+      - provisioner-server-data
+      - provisioner-machine_key
+      - provisioner-dhcp-data
+      - dns_all_data
+      - network-admin
     requires:
       - provisioner-dhcp-server
   - name: provisioner-os-install
     jig: script
+    wants-attribs:
+      - provisioner-server-data
     requires:
       - provisioner-dhcp-server
     flags:


### PR DESCRIPTION
This pull request series switches the core Crowbar framework to be
smarter about injecting just the attributes that a role declares that
it needs, instead of just smashing everything that could be in scope
together.

 crowbar.yml | 24 ++++++++++++++++++++----
 1 file changed, 20 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: dccf04341e8a02b81a47fd321efe6c0256033410

Crowbar-Release: development
