### PR TITLE
enable kernel output on serial console

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/default.erb
+++ b/chef/cookbooks/provisioner/templates/default/default.erb
@@ -3,5 +3,5 @@ PROMPT 0
 TIMEOUT 10
 LABEL <%= @install_name %>
   KERNEL <%= @kernel %>
-  append initrd=<%= @initrd %> <%= @append_line %>
+  append initrd=<%= @initrd %> console=ttyS0,115200 console=tty <%= @append_line %>
   IPAPPEND 2


### PR DESCRIPTION
this applies to sleshammer, autoyast install and installed system.

To see autoyast on serial, user must omit console=tty or switch order.
That also makes serial login possible on installed system.
