### PR TITLE
Allow the provisioner to handle building Sledgehammer. [1/3]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,21 +3,15 @@
 [[ $BC_CACHE ]] || export BC_CACHE="$HOME/.crowbar-build-cache/barclamps/provisioner"
 [[ $CROWBAR_DIR ]] || export CROWBAR_DIR="$HOME/crowbar"
 [[ $BC_DIR ]] || export BC_DIR="$HOME/crowbar/barclamps/provisioner"
+export SLEDGEHAMMER_PXE_DIR="$BC_CACHE/tftpboot"
 
 echo "Using: BC_CACHE = $BC_CACHE"
 echo "Using: CROWBAR_DIR = $CROWBAR_DIR"
 echo "Using: BC_DIR = $BC_DIR"
 
-bc_needs_build() {
-    true
-}
+
+bc_needs_build() [[ ! -f $SLEDGEHAMMER_PXE_DIR/initrd0.img ]]
 
 bc_build() {
-    mkdir -p "$BC_CACHE/files/wsman"
-    mkdir -p "$BC_CACHE/gems"
-
-    cd "$BC_DIR/updates/wsman"
-    gem build wsman.gemspec
-
-    mv "$BC_DIR"/updates/wsman/wsman*.gem "$BC_CACHE/gems"
+    die "Please run $BC_DIR/build_sledgehammer.sh to build Sledgehammer!"
 }

--- a/build_sledgehammer.sh
+++ b/build_sledgehammer.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+#
+# Build a sledgehammer image for Crowbar and put it in the build cache.
+
+# Copyright 2011, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: VictorLowther
+
+# We always use the C language and locale
+export LANG="C"
+export LC_ALL="C"
+
+GEM_RE='([^0-9].*)-([0-9].*)'
+
+readonly currdir="$PWD"
+export PATH="$PATH:/sbin:/usr/sbin:/usr/local/sbin"
+
+if ! [[ $CACHE_DIR ]]; then
+    # Source our config file if we have one
+    [[ -f $HOME/.build-crowbar.conf ]] && \
+        . "$HOME/.build-crowbar.conf"
+    # Look for a local one.
+    [[ -f build-crowbar.conf ]] && \
+        . "build-crowbar.conf"
+fi
+# Always run in verbose mode for now.
+VERBOSE=true
+SLEDGEHAMMER_OS="centos-6.4"
+OS_TO_STAGE="$SLEDGEHAMMER_OS"
+OS_TOKEN="$OS_TO_STAGE"
+
+# Location for caches that should not be erased between runs
+[[ $CACHE_DIR ]] || CACHE_DIR="$HOME/.crowbar-build-cache"
+
+# The directory that we will mount the OS .ISO on .
+[[ $IMAGE_DIR ]] || \
+    IMAGE_DIR="$CACHE_DIR/$OS_TOKEN/sledgehammer-image"
+
+# Location to store .iso images that we use in the build process.
+# These are usually OS install DVDs that we will stage Crowbar on to.
+[[ $ISO_LIBRARY ]] || ISO_LIBRARY="$CACHE_DIR/iso"
+
+CHROOT="$CACHE_DIR/$OS_TOKEN/sledgehammer-chroot"
+sudo rm -rf "$CHROOT"
+
+mkdir -p "$CACHE_DIR" "$IMAGE_DIR" "$CHROOT"
+
+# Location of the Crowbar checkout we are building from.
+[[ $CROWBAR_DIR ]] || CROWBAR_DIR="${0%/*}/../.."
+[[ $CROWBAR_DIR = /* ]] || CROWBAR_DIR="$currdir/$CROWBAR_DIR"
+[[ -f $CROWBAR_DIR/build_crowbar.sh && -d $CROWBAR_DIR/.git ]] || \
+    die "$CROWBAR_DIR is not a git checkout of Crowbar!"
+export CROWBAR_DIR
+
+# Directory that holds our Sledgehammer PXE tree.
+[[ $SLEDGEHAMMER_PXE_DIR ]] || SLEDGEHAMMER_PXE_DIR="$CACHE_DIR/barclamps/provisioner/tftpboot"
+
+unset CROWBAR_BUILD_PID
+# Source our common build functions
+. "$CROWBAR_DIR/build_lib.sh" || exit 1
+. "$CROWBAR_DIR/test_lib.sh" || exit 1
+
+if ! which cpio &>/dev/null; then
+    die "Cannot find cpio, we cannot proceed."
+fi
+
+if ! which rpm rpm2cpio &>/dev/null; then
+    die "Cannot find rpm and rpm2cpio, we cannot proceed."
+fi
+
+if ! which ruby &>/dev/null; then
+    die "You must have Ruby installed to run this script.  We cannot proceed."
+fi
+
+# Make sure that we actually know how to build the ISO we were asked to
+# build.  If we do not, print a helpful error message.
+if ! [[ $OS_TO_STAGE && -d $CROWBAR_DIR/$OS_TO_STAGE-extra && \
+    -f $CROWBAR_DIR/$OS_TO_STAGE-extra/build_lib.sh ]]; then
+    cat <<EOF
+You must pass the name of the operating system you want to stage Sledgehammer
+on to.  Valid choices are:
+EOF
+cd "$CROWBAR_DIR"
+for d in *-extra; do
+    [[ -d $d && -f $d/build_lib.sh ]] || continue
+    echo "    ${d%-extra}"
+done
+exit 1
+fi
+
+SLEDGEHAMMER_CHROOT_CACHE="$CACHE_DIR/sledgehammer/$OS_TO_STAGE/chroot_cache"
+SLEDGEHAMMER_LIVECD_CACHE="$CACHE_DIR/sledgehammer/$OS_TO_STAGE/livecd_cache"
+
+[[ -f $CROWBAR_DIR/$OS_TO_STAGE-extra/build_sledgehammer_lib.sh && \
+    -f $CROWBAR_DIR/$OS_TO_STAGE-extra/sledgehammer.ks ]] || \
+    die "Do not know how to build Sledgehammer on this OS!"
+
+. "$CROWBAR_DIR/$OS_TO_STAGE-extra/build_lib.sh"
+
+# This file contains library routines needed to build Sledgehammer
+
+EXTRA_REPOS=('http://mirror.centos.org/centos/6/os/x86_64' \
+    'http://mirror.centos.org/centos/6/updates/x86_64' \
+    'http://mirror.centos.org/centos/6/extras/x86_64' \
+    'http://mirror.us.leaseweb.net/epel/6/x86_64' \
+    'http://www.nanotechnologies.qc.ca/propos/linux/centos-live/x86_64/live' \
+    'http://rbel.frameos.org/stable/el6/x86_64' \
+    'http://download.opensuse.org/repositories/Openwsman/CentOS_CentOS-6')
+
+setup_sledgehammer_chroot() {
+    local repo rnum
+    local packages=() pkg
+    local files=() file
+    local mirror="${EXTRA_REPOS[0]}"
+    local -A base_pkgs
+    # Build a hash of base packages. We will use this to track the packages we found in the mirror.
+    for pkg in "${OS_BASIC_PACKAGES[@]}"; do
+        base_pkgs["$pkg"]="needed"
+    done
+    # Fourth, get a list of packages in the mirror that we will use.
+    match_re='^([A-Za-z0-9._+-]+)-([0-9]+:)?([0-9a-zA-Z._]+)-([^-]+)(\.el6.*)?\.(x86_64|noarch)\.rpm'
+    while read file; do
+        # Do we actaully care at all about this file?
+        [[ $file =~ $match_re ]] || continue
+        # Is this a file we need to download?
+        [[ ${base_pkgs["${BASH_REMATCH[1]}"]} ]] || continue
+        # It is. Mark it as found and put it in the list.
+        base_pkgs["${BASH_REMATCH[1]}"]="found"
+        files+=("-O" "${mirror}/Packages/$file")
+    done < <(curl -sfL "{$mirror}/Packages/" | \
+        sed -rn 's/.*"([^"]+\.(x86_64|noarch).rpm)".*/\1/p')
+    # Fifth, make sure we found all our packages.
+    for pkg in "${base_pkgs[@]}"; do
+        [[ $pkg = found ]] && continue
+        die "Not all files for CentOS chroot found."
+    done
+    # Sixth, suck all of our files and install them in one go
+    sudo mkdir -p "$CHROOT"
+    (
+        set -e
+        set -o pipefail
+        cd "$CHROOT"
+        debug "Fetching files needed for chroot"
+        curl -sfL "${files[@]}" || exit 1
+        for file in *.rpm; do
+            debug "Extracting $file"
+            rpm2cpio "$file" | sudo cpio --extract --make-directories \
+                --no-absolute-filenames --preserve-modification-time &>/dev/null
+            if [[ $file =~ (centos|redhat)-release ]]; then
+                sudo mkdir -p "$CHROOT/tmp"
+                sudo cp "$file" "$CHROOT/tmp/${file##*/}"
+                postcmds+=("/bin/rpm -ivh --force --nodeps /tmp/${file##*/}")
+            fi
+            rm "$file"
+        done
+        # Seventh, fix up the chroot so that it is fully functional.
+        sudo cp /etc/resolv.conf "$CHROOT/etc/resolv.conf"
+        for d in /proc /sys /dev /dev/pts /dev/shm; do
+            [[ -L $d ]] && d="$(readlink -f "$d")"
+            mkdir -p "${CHROOT}$d"
+            sudo mount --bind "$d" "${CHROOT}$d"
+        done
+        # Eighth, run any post cmds we got earlier
+        for cmd in "${postcmds[@]}"; do
+            in_chroot $cmd
+        done
+    ) || die "Not all files needed for CentOS chroot downloaded."
+    sudo rm -f "$CHROOT/etc/yum.repos.d/"*
+    rnum=0
+    for repo in "${EXTRA_REPOS[@]}"; do
+        add_repos "bare r${rnum} 10 $repo"
+        rnum=$((rnum + 1))
+    done
+    # Eleventh, bootstrap the rest of the chroot with yum.
+    in_chroot yum -y install yum yum-downloadonly createrepo
+    # fastestmirror support behind a proxy is not that good.
+    [[ -f $CHROOT/etc/yum/pluginconf.d/fastestmirror.conf ]] && \
+        in_chroot sed -ie '/^enabled/ s/1/0/' \
+        /etc/yum/pluginconf.d/fastestmirror.conf
+    # Make sure yum does not throw away our caches for any reason.
+    in_chroot /bin/sed -i -e '/keepcache/ s/0/1/' /etc/yum.conf
+    in_chroot sh -c "echo 'exclude = *.i386' >>/etc/yum.conf"
+    # fourth, have yum bootstrap everything else into usefulness
+    chroot_install livecd-tools tar
+}
+
+setup_sledgehammer_chroot
+sudo cp "$CROWBAR_DIR/barclamps/provisioner/sledgehammer.ks" "$CHROOT/mnt"
+sudo cp "$CROWBAR_DIR/barclamps/provisioner/sledgehammer-common/"* "$CHROOT/mnt"
+mkdir -p "$SLEDGEHAMMER_CHROOT_CACHE"
+mkdir -p "$SLEDGEHAMMER_LIVECD_CACHE"
+in_chroot mkdir -p /mnt/cache
+sudo mount --bind "$SLEDGEHAMMER_CHROOT_CACHE" "$CHROOT/$CHROOT_PKGDIR"
+sudo mount --bind "$SLEDGEHAMMER_LIVECD_CACHE" "$CHROOT/mnt/cache"
+in_chroot touch /mnt/make_sledgehammer
+in_chroot chmod 777 /mnt/make_sledgehammer
+echo '#!/bin/bash' >>"$CHROOT/mnt/make_sledgehammer"
+if [[ $USE_PROXY = "1" ]]; then
+    printf "\nexport no_proxy=%q http_proxy=%q\n" \
+        "$no_proxy" "$http_proxy" >> "$CHROOT/mnt/make_sledgehammer"
+    printf "\nexport NO_PROXY=%q HTTP_PROXY=%q\n" \
+        "$no_proxy" "$http_proxy" >> "$CHROOT/mnt/make_sledgehammer"
+fi
+cat >> "$CHROOT/mnt/make_sledgehammer" <<EOF
+set -e
+cd /mnt
+livecd-creator --config=sledgehammer.ks --cache=./cache -f sledgehammer
+$SLEDGEECHO rm -fr /mnt/tftpboot
+livecd-iso-to-pxeboot sledgehammer.iso
+$SLEDGEECHO /bin/rm /mnt/sledgehammer.iso
+EOF
+in_chroot ln -s /proc/self/mounts /etc/mtab
+in_chroot /mnt/make_sledgehammer
+mkdir -p "$SLEDGEHAMMER_PXE_DIR"
+cp -af "$CHROOT/mnt/tftpboot/"* "$SLEDGEHAMMER_PXE_DIR"
+$SLEDGEECHO in_chroot /bin/rm -rf /mnt/tftpboot
+
+# Make sure that the loopback kernel module is loaded.
+[[ -d /sys/module/loop ]] || sudo modprobe loop
+
+while read line; do
+    sudo losetup -d "${line%%:*}"
+done < <(sudo losetup -a |grep sledgehammer.iso)
+
+[[ -f $SLEDGEHAMMER_PXE_DIR/initrd0.img ]]

--- a/build_sledgehammer_lib.sh
+++ b/build_sledgehammer_lib.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# This file contains library routines needed to build Sledgehammer
+
+EXTRA_REPOS=('http://mirror.centos.org/centos/6/os/x86_64' \
+    'http://mirror.centos.org/centos/6/updates/x86_64' \
+    'http://mirror.centos.org/centos/6/extras/x86_64' \
+    'http://mirror.us.leaseweb.net/epel/6/x86_64' \
+    'http://www.nanotechnologies.qc.ca/propos/linux/centos-live/x86_64/live' \
+    'http://rbel.frameos.org/stable/el6/x86_64' \
+    'http://download.opensuse.org/repositories/Openwsman/CentOS_CentOS-6')
+
+setup_sledgehammer_chroot() {
+    local repo rnum
+    local packages=() pkg
+    local files=() file
+    local mirror="${EXTRA_REPOS[0]}"
+    local -A base_pkgs
+    # Build a hash of base packages. We will use this to track the packages we found in the mirror.
+    for pkg in "${OS_BASIC_PACKAGES[@]}"; do
+        base_pkgs["$pkg"]="needed"
+    done
+    # Fourth, get a list of packages in the mirror that we will use.
+    match_re='^([A-Za-z0-9._+-]+)-([0-9]+:)?([0-9a-zA-Z._]+)-([^-]+)(\.el6.*)?\.(x86_64|noarch)\.rpm'
+    while read file; do
+        # Do we actaully care at all about this file?
+        [[ $file =~ $match_re ]] || continue
+        # Is this a file we need to download?
+        [[ ${base_pkgs["${BASH_REMATCH[1]}"]} ]] || continue
+        # It is. Mark it as found and put it in the list.
+        base_pkgs["${BASH_REMATCH[1]}"]="found"
+        files+=("-O" "${mirror}/Packages/$file")
+    done < <(curl -sfL "{$mirror}/Packages/" | \
+        sed -rn 's/.*"([^"]+\.(x86_64|noarch).rpm)".*/\1/p')
+    # Fifth, make sure we found all our packages.
+    for pkg in "${base_pkgs[@]}"; do
+        [[ $pkg = found ]] && continue
+        die "Not all files for CentOS chroot found."
+    done
+    # Sixth, suck all of our files and install them in one go
+    sudo mkdir -p "$CHROOT"
+    (
+        set -e
+        set -o pipefail
+        cd "$CHROOT"
+        debug "Fetching files needed for chroot"
+        curl -sfL "${files[@]}" || exit 1
+        for file in *.rpm; do
+            debug "Extracting $file"
+            rpm2cpio "$file" | sudo cpio --extract --make-directories \
+                --no-absolute-filenames --preserve-modification-time &>/dev/null
+            if [[ $file =~ (centos|redhat)-release ]]; then
+                sudo mkdir -p "$CHROOT/tmp"
+                sudo cp "$file" "$CHROOT/tmp/${file##*/}"
+                postcmds+=("/bin/rpm -ivh --force --nodeps /tmp/${file##*/}")
+            fi
+            rm "$file"
+        done
+        # Seventh, fix up the chroot so that it is fully functional.
+        sudo cp /etc/resolv.conf "$CHROOT/etc/resolv.conf"
+        for d in /proc /sys /dev /dev/pts /dev/shm; do
+            [[ -L $d ]] && d="$(readlink -f "$d")"
+            mkdir -p "${CHROOT}$d"
+            sudo mount --bind "$d" "${CHROOT}$d"
+        done
+        # Eighth, run any post cmds we got earlier
+        for cmd in "${postcmds[@]}"; do
+            in_chroot $cmd
+        done
+    ) || die "Not all files needed for CentOS chroot downloaded."
+    sudo rm -f "$CHROOT/etc/yum.repos.d/"*
+    rnum=0
+    for repo in "${EXTRA_REPOS[@]}"; do
+        add_repos "bare r${rnum} 10 $repo"
+        rnum=$((rnum + 1))
+    done
+    # Eleventh, bootstrap the rest of the chroot with yum.
+    in_chroot yum -y install yum yum-downloadonly createrepo
+    # fastestmirror support behind a proxy is not that good.
+    [[ -f $CHROOT/etc/yum/pluginconf.d/fastestmirror.conf ]] && \
+        in_chroot sed -ie '/^enabled/ s/1/0/' \
+        /etc/yum/pluginconf.d/fastestmirror.conf
+    # Make sure yum does not throw away our caches for any reason.
+    in_chroot /bin/sed -i -e '/keepcache/ s/0/1/' /etc/yum.conf
+    in_chroot sh -c "echo 'exclude = *.i386' >>/etc/yum.conf"
+    # fourth, have yum bootstrap everything else into usefulness
+    chroot_install livecd-tools tar
+}

--- a/chef/cookbooks/provisioner/templates/default/control.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/control.sh.erb
@@ -17,13 +17,6 @@
 # We get the following variables from start-up.sh
 # MAC BOOTDEV ADMIN_IP DOMAIN HOSTNAME HOSTNAME_MAC MYIP
 
-if [[ $PWD != /tmp ]]; then
-    cd /tmp
-    exec ./control.sh
-fi
-
-exec >>/tmp/control.log
-exec 2>>/tmp/control.log
 set -x
 shopt -s extglob
 export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
@@ -33,91 +26,8 @@ export https_proxy="$http_proxy"
 provisioner="<%=@provisioner_web%>"
 crowbar="http://<%=@provisioner_name%>:3000"
 crowbar_v4="http://<%=@v4_addr%>:3000"
-host_re='crowbar\.fqdn=([^ ]+)'
-v6prefix_re='crowbar\.v6prefix=([^ ]+)'
 
-# Get our passed-in hostname
-if ! [[ $(cat /proc/cmdline) =~ $host_re ]]; then
-    NEED_CREATE=true
-    HOSTNAME="d${MAC//:/-}.${DOMAIN}"
-else
-    HOSTNAME="${BASH_REMATCH[1]}"
-fi
-
-sed -i -e "s/\(127\.0\.0\.1.*\)/127.0.0.1 $HOSTNAME ${HOSTNAME%%.*} localhost.localdomain localhost/" /etc/hosts
-if [[ -f /etc/sysconfig/network ]]; then
-    sed -i -e "s/HOSTNAME=.*/HOSTNAME=${HOSTNAME}/" /etc/sysconfig/network
-fi
-echo "${HOSTNAME#*.}" >/etc/domainname
-hostname "$HOSTNAME"
-
-# Our first two curl calls need ot happen over IPv4,
-# because that is all we are guaranteed to have at that point.
-if [[ $NEED_CREATE ]]; then
-    curl -g --digest -u "$CROWBAR_KEY" -X POST \
-        -d "name=$HOSTNAME" \
-        "$crowbar_v4/api/v2/nodes/"
-else
-    # We know who we should be, but we are coming back to life.
-    # Mark us as dead to let our role resynchronize, and
-    # make sure the crowbar framework is aware that we booted into
-    # Sledgehammer.
-    curl -g --digest -u "$CROWBAR_KEY" \
-        -X PUT "$crowbar_v4/api/v2/nodes/$HOSTNAME" \
-        -d 'alive=false' \
-        -d 'bootenv=sledgehammer'
-fi
-
-# Ditch NFS for now.
-umount -l /install-logs/
-umount -l /updates
-
-ip_re='([0-9a-f.:]+/[0-9]+)'
-# Figure out what IP addresses we should have.
-netline=$(curl -g --digest -u "$CROWBAR_KEY" \
-    -X GET "$crowbar_v4/network/api/v2/networks/admin/allocations" \
-    -d "node=$HOSTNAME")
-
-# Bye bye to DHCP.
-killall dhclient
-ip addr flush "$BOOTDEV"
-
-# Add our new IP addresses.
-nets=(${netline//,/ })
-for net in "${nets[@]}"; do
-    [[ $net =~ $ip_re ]] || continue
-    net=${BASH_REMATCH[1]}
-    # Make this more complicated and exact later.
-    ip addr add "$net" dev "$BOOTDEV" || :
-done
-
-# Figure out what IP addresses the admin node has
-netline=$(curl -g --digest -u "$CROWBAR_KEY" \
-    -X GET "$crowbar_v4/network/api/v2/networks/admin/allocations" \
-    -d "node=<%=@provisioner_name%>")
-
-# Update our /etc/resolv.conf with the IP address of our admin node,
-# which is assumed to be our nameserver
-chattr -i /etc/resolv.conf || :
-echo "domain $DOMAIN" >/etc/resolv.conf.new
-
-nets=(${netline//,/ })
-for net in "${nets[@]}"; do
-    [[ $net =~ $ip_re ]] || continue
-    net=${BASH_REMATCH[1]}
-    echo "nameserver ${net%%/*}" >> /etc/resolv.conf.new
-done
-
-mv -f /etc/resolv.conf.new /etc/resolv.conf
-
-# Force reliance on DNS
-echo '127.0.0.1 localhost' >/etc/hosts
-echo '::1 localhost6' >>/etc/hosts
-
-# Wait for the DNS server to notice that we are alive.
-while ! ping6 -c 1 -w 1 "$HOSTNAME"; do
-    sleep 1
-done
+# Set up just enough infrastructure to let the jigs work.
 
 # Synchronize our date
 ntpdate "<%=@provisioner_name%>"
@@ -150,9 +60,6 @@ cat >/root/.ssh/authorized_keys <<EOF
 <%= @keys %>
 EOF
 
-echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config
-service sshd restart
-
 # Mark us as alive.
 # Mark the node as alive.
 curl -g --digest -u "$CROWBAR_KEY" \
@@ -161,46 +68,6 @@ curl -g --digest -u "$CROWBAR_KEY" \
 
 # We are alive, and we should have a host entry created now.  Wait forever to do something.
 exit 0
-
-# The rest of this will vanish once we migrate over to driving these via the script jig
-MYINDEX=${MYIP##*.}
-DHCP_STATE=$(grep -o -E 'crowbar\.state=[^ ]+' /proc/cmdline)
-DHCP_STATE=${DHCP_STATE#*=}
-MAXTRIES=5
-BMC_ADDRESS=""
-BMC_NETMASK=""
-BMC_ROUTER=""
-ALLOCATED=false
-CHEF_SERVER="http://$ADMIN_IP:4000"
-export DHCP_STATE MYINDEX BMC_ADDRESS BMC_NETMASK BMC_ROUTER ADMIN_IP
-export ALLOCATED HOSTNAME CROWBAR_KEY CROWBAR_STATE http_proxy https_proxy
-
-# Make sure date is up-to-date
-NTPDATE=/usr/sbin/ntpdate
-
-# SLES doesn't have ntpdate use sntp there. On openSUSE 12.2 and newer
-# ntpdate is present again
-[ -f /etc/SuSE-release ] && grep "Enterprise" /etc/SuSE-release && NTPDATE="sntp -P no -r"
-until $NTPDATE $ADMIN_IP || [[ $DHCP_STATE = 'debug' ]]
-do
-  echo "Waiting for NTP server"
-  sleep 1
-done
-
-
-# Add full code set
-if [ -e /updates/full_data.sh ] ; then
-  cp /updates/full_data.sh /tmp
-  /tmp/full_data.sh
-fi
-
-# Get stuff out of nfs.
-cp /updates/parse_node_data /tmp
-
-mkdir -p /etc/chef
-cp "/updates/$HOSTNAME/client.pem" /etc/chef
-
-. "/updates/control_lib.sh"
 
 nuke_everything() {
     # Make sure that the kernel knows about all the partitions
@@ -224,98 +91,3 @@ nuke_everything() {
     ## for good measure, nuke partition tables on disks (nothing should remain bootable)
     for i in `ls /dev/sd?`; do  parted -m -s  $i mklabel bsd ; sleep 1 ; done
 }
-
-# If there are pre/post transition hooks for this state (per system or not),
-# handle them.
-run_hooks() {
-    # $1 = state
-    # $2 = pre or post
-    local hookdirs=() hookdir='' hook=''
-    # We only handle pre and post hooks.  Anything else is a bug in
-    # control.sh that we should debug.
-    case $3 in
-        pre) hookdirs=("/updates/$HOSTNAME/$1-$2" "/updates/$1-$2");;
-        post) hookdirs=("/updates/$1-$2" "/updates/$HOSTNAME/$1-$2");;
-        *) post_state debug; reboot_system;;
-    esac
-    for hookdir in "${hookdirs[@]}"; do
-        [[ -d $hookdir ]] || continue
-        for hook in "$hookdir/"*.hook; do
-            [[ -x $hook ]] || continue
-            # If a hook fails, then Something Weird happened, and it
-            # needs to be debugged.
-            export HOOKSTATE="$1-$2" HOOKNAME="${hook##*/}"
-            if "$hook"; then
-                unset HOOKSTATE HOOKNAME
-                get_state
-                continue
-            else
-                post_state debug
-                reboot_system
-            fi
-        done
-    done
-}
-
-run_chef_client() {
-    # $1 = URL of server
-    # $2 = name of client
-    # $3 = Crowbar state client is in.
-    chef-client -S "$CHEF_SERVER" && return
-    post_state debug
-    exit
-}
-
-walk_node_through () {
-    # $1 = hostname for chef-client run
-    # $@ = states to walk through
-    local f='' state=''
-    while (( $# > 0)); do
-        if (( $# == 1)); then
-            report_state "$1"
-        else
-            post_state "$1"
-        fi
-        run_hooks "$1" pre
-        run_chef_client
-        run_hooks "$1" post
-        shift
-    done
-}
-
-# If there is a custom control.sh for this system, source it.
-[[ -x /updates/$HOSTNAME/control.sh ]] && \
-    . "/updates/$HOSTNAME/control.sh"
-
-discover() {
-    echo "Discovering with: $HOSTNAME"
-    walk_node_through discovering
-    post_state discovered
-    run_chef_client
-}
-
-hardware_install () {
-    wait_for_allocated "$HOSTNAME"
-    echo "Hardware installing with: $HOSTNAME"
-    nuke_everything
-    walk_node_through hardware-installing hardware-installed
-    nuke_everything
-    post_state installing
-}
-
-hwupdate () {
-    walk_node_through hardware-updating hardware-updated
-}
-
-run_chef_client
-
-__post_state discovered
-exit 0
-
-case $DHCP_STATE in
-    discovery) discover && hardware_install;;
-    hwinstall) hardware_install;;
-    update) hwupdate;;
-esac 2>&1 | tee -a /install-logs/$HOSTNAME-update.log
-[[ $DHCP_STATE = 'debug' ]] && exit
-reboot_system

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -221,3 +221,5 @@ rpms:
 extra_files:
   - http://downloads.sourceforge.net/project/elilo/elilo/elilo-3.16/elilo-3.16-all.tar.gz
   - https://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chef-11.6.0-1.el6.x86_64.rpm
+
+build_cmd: build.sh

--- a/crowbar_engine/barclamp_provisioner/app/models/barclamp_provisioner/dhcp_database.rb
+++ b/crowbar_engine/barclamp_provisioner/app/models/barclamp_provisioner/dhcp_database.rb
@@ -56,8 +56,6 @@ class BarclampProvisioner::DhcpDatabase < Role
             end
           end
         end
-        # we need to have at least 1 mac (from preload or inets)
-        next unless mac_list.length > 0
         # add this node to the DHCP clients list
         clients[node.name] = {
           "mac_addresses" => mac_list.sort,

--- a/sledgehammer-common/build.expect
+++ b/sledgehammer-common/build.expect
@@ -1,0 +1,10 @@
+#!/usr/bin/expect
+
+spawn ./build_sledgehammer.sh
+expect -timeout 600 {
+       -re "^.*$" { exp_continue }
+       eof {
+       	   catch wait result
+	   exit [lindex $result 3]
+       }
+}

--- a/sledgehammer-common/dhclient.conf
+++ b/sledgehammer-common/dhclient.conf
@@ -1,0 +1,12 @@
+
+option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
+option dhcp-client-state code 225 = unsigned integer 16;
+option dhcp-client-debug code 226 = unsigned integer 16;
+
+send host-name "<hostname>";
+request subnet-mask, broadcast-address, time-offset, routers,
+        domain-name, domain-name-servers, domain-search, host-name,
+        netbios-name-servers, netbios-scope, interface-mtu,
+        rfc3442-classless-static-routes, ntp-servers,
+        dhcp-client-state, dhcp-client-debug;
+

--- a/sledgehammer-common/sshd_config
+++ b/sledgehammer-common/sshd_config
@@ -1,0 +1,14 @@
+# Default sshd config for Sledgehammer in Crowbar 2
+
+Protocol 2
+SyslogFacility AUTHPRIV
+PermitRootLogin without-password
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+GSSAPIAuthentication yes
+GSSAPICleanupCredentials yes
+UsePAM yes
+AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+AcceptEnv LC_IDENTIFICATION LC_ALL
+Subsystem sftp /usr/libexec/openssh/sftp-server

--- a/sledgehammer-common/start-up.sh
+++ b/sledgehammer-common/start-up.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
+set -x
+set -e
+shopt -s extglob
+
+get_param() {
+    [[ $(cat /proc/cmdline) =~ $1 ]] && echo "${BASH_REMATCH[1]}"
+}
+
+is_suse() [[ -f /etc/SuSE-release ]]
+
+DHCPDIR=/var/lib/dhclient
+RSYSLOGSERVICE=rsyslog
+
+is_suse && {
+ DHCPDIR=/var/lib/dhcp
+ RSYSLOGSERVICE=syslog
+}
+
+# Some useful boot parameter matches
+ip_re='([0-9a-f.:]+/[0-9]+)'
+bootif_re='BOOTIF=([^ ]+)'
+host_re='crowbar\.fqdn=([^ ]+)'
+install_key_re='crowbar\.install\.key=([^ ]+)'
+provisioner_re='provisioner\.web=([^ ]+)'
+crowbar_re='crowbar\.web=([^ ]+)'
+domain_re='crowbar\.dns\.domain=([^ ]+)'
+dns_server_re='crowbar\.dns\.servers=([^ ]+)'
+
+# Grab the boot parameters we should always be passed
+
+# install key first
+export CROWBAR_KEY="$(get_param "$install_key_re")"
+
+# Provisioner and Crowbar web endpoints next
+export PROVISIONER_WEB="$(get_param "$provisioner_re")"
+export CROWBAR_WEB="$(get_param "$crowbar_re")"
+export DOMAIN="$(get_param "$domain_re")"
+export DNS_SERVERS="$(get_param "$dns_server_re")"
+
+# Test to see if we got everything we must have.
+# Die horribly otherwise.
+if ! [[ $CROWBAR_KEY && $PROVISIONER_WEB && $CROWBAR_WEB && \
+    $DOMAIN && $DNS_SERVERS ]]; then
+    echo "Sledgehammer was not booted off a Crowbar 2 provisioner."
+    echo "This cannot happen"
+    exit 1
+fi
+
+# Figure out where we PXE booted from.
+if [[ $(cat /proc/cmdline) =~ $bootif_re ]]; then
+    MAC="${BASH_REMATCH[1]//-/:}"
+    MAC="${MAC#*:}"
+elif [[ -d /sys/firmware/efi ]]; then
+    declare -A boot_entries
+    bootent_re='^Boot([0-9]{4})'
+    efimac_re='MAC\(([0-9a-f]+)'
+    while read line; do
+        k="${line%% *}"
+        v="${line#* }"
+        if [[ $k = BootCurrent:* ]]; then
+            current_bootent="${line##BootCurrent: }"
+        elif [[ $k =~ $bootent_re ]]; then
+            boot_entries["${BASH_REMATCH[1]}"]="$v"
+        fi
+    done < <(efibootmgr -v)
+
+    if [[ ${boot_entries["$current_bootent"]} =~ $efimac_re ]]; then
+        MAC=''
+        for o in 0 2 4 6 8 10; do
+            MAC+="${BASH_REMATCH[1]:$o:2}:"
+        done
+        MAC=${MAC%:}
+    fi
+fi
+for nic in /sys/class/net/*; do
+    [[ -f $nic/address && -f $nic/type && \
+        $(cat "$nic/type") = 1 && \
+        $(cat "$nic/address") = $MAC ]] || continue
+    BOOTDEV="${nic##*/}"
+    break
+done
+
+if [[ ! $BOOTDEV ]]; then
+    echo "We don't know what the MAC address of our boot NIC was!"
+    exit 1
+fi
+
+killall dhclient && sleep 5
+# Make sure our PXE interface is up, then fire up DHCP on it.
+ip link set "$BOOTDEV" up || :
+dhclient "$BOOTDEV" || :
+
+bootdev_ip_re='inet ([0-9.]+)/([0-9]+)'
+if ! [[ $(ip -4 -o addr show dev $BOOTDEV) =~ $bootdev_ip_re ]]; then
+    echo "We did not get an address on $BOOTDEV"
+    echo "Things will end badly."
+    exit 1
+fi
+
+# Let Crowbar know what is happening.
+if ! [[ $(cat /proc/cmdline) =~ $host_re ]]; then
+    export HOSTNAME="d${MAC//:/-}.${DOMAIN}"
+    curl -f -g --digest -u "$CROWBAR_KEY" -X POST \
+        -d "name=$HOSTNAME" \
+        -d "mac=$MAC" \
+        "$CROWBAR_WEB/api/v2/nodes/"
+else
+    export HOSTNAME="${BASH_REMATCH[1]}"
+    curl -f -g --digest -u "$CROWBAR_KEY" \
+        -X PUT "$CROWBAR_WEB/api/v2/nodes/$HOSTNAME" \
+        -d 'alive=false' \
+        -d 'bootenv=sledgehammer'
+fi
+
+# Figure out what IP addresses we should have.
+netline=$(curl -f -g --digest -u "$CROWBAR_KEY" \
+    -X GET "$CROWBAR_WEB/network/api/v2/networks/admin/allocations" \
+    -d "node=$HOSTNAME")
+
+# Bye bye to DHCP.
+killall dhclient || :
+ip addr flush "$BOOTDEV"
+
+# Add our new IP addresses.
+nets=(${netline//,/ })
+for net in "${nets[@]}"; do
+    [[ $net =~ $ip_re ]] || continue
+    net=${BASH_REMATCH[1]}
+    # Make this more complicated and exact later.
+    ip addr add "$net" dev "$BOOTDEV" || :
+done
+
+# Set our hostname for everything else.
+if is_suse; then
+    echo "$HOSTNAME" > /etc/HOSTNAME
+else
+    if [ -f /etc/sysconfig/network ] ; then
+      sed -i -e "s/HOSTNAME=.*/HOSTNAME=${HOSTNAME}/" /etc/sysconfig/network
+    fi
+    echo "${HOSTNAME#*.}" >/etc/domainname
+fi
+hostname "$HOSTNAME"
+
+# Update our /etc/resolv.conf with the IP address of our DNS servers,
+# which were passed to us via kernel param.
+chattr -i /etc/resolv.conf || :
+echo "domain $DOMAIN" >/etc/resolv.conf.new
+
+for server in ${DNS_SERVERS//,/ }; do
+    echo "nameserver ${server}" >> /etc/resolv.conf.new
+done
+
+mv -f /etc/resolv.conf.new /etc/resolv.conf
+
+# Force reliance on DNS
+echo '127.0.0.1 localhost' >/etc/hosts
+echo '::1 localhost6' >>/etc/hosts
+
+# Wait for up to 30 seconds for Crowbar to notice that we are alive.
+for (( count=0; count < 30; count=$count + 1)); do
+    ping6 -c 1 -w 1 "$HOSTNAME" && break
+    sleep 1
+done
+
+if [[ $? != 0 ]]; then
+    echo "Crowbar did not register that we exist!"
+    exit 1
+fi
+
+while [[ ! -x /tmp/control.sh ]]; do
+    curl -s -f -L -o /tmp/control.sh "$PROVISIONER_WEB/nodes/$HOSTNAME/control.sh" || :
+    if grep -q '^exit 0$' /tmp/control.sh && \
+        head -1 /tmp/control.sh | grep -q '^#!/bin/bash'; then
+        chmod 755 /tmp/control.sh
+        break
+    fi
+    sleep 1
+done
+
+export CROWBAR_KEY PROVISIONER_WEB CROWBAR_WEB
+export MAC BOOTDEV DOMAIN HOSTNAME
+
+[[ -x /tmp/control.sh ]] && exec /tmp/control.sh
+
+echo "Did not get control.sh from $PROVISIONER_WEB/nodes/$HOSTNAME/control.sh"
+exit 1

--- a/sledgehammer.ks
+++ b/sledgehammer.ks
@@ -1,0 +1,131 @@
+lang en_US.UTF-8
+keyboard us
+timezone US/Eastern
+auth --useshadow --enablemd5
+# crowbar
+rootpw --iscrypted $1$H6F/NLec$Fps2Ut0zY4MjJtsa1O2yk0
+selinux --disabled
+firewall --disabled
+
+repo --name=a-base    --baseurl=http://mirror.centos.org/centos/6/os/$basearch
+repo --name=a-updates --baseurl=http://mirror.centos.org/centos/6/updates/$basearch
+repo --name=a-extras  --baseurl=http://mirror.centos.org/centos/6/extras/$basearch
+repo --name=a-live    --baseurl=http://www.nanotechnologies.qc.ca/propos/linux/centos-live/$basearch/live
+repo --name=a-wsman   --baseurl=http://download.opensuse.org/repositories/Openwsman/CentOS_CentOS-6
+%packages
+@core
+OpenIPMI
+OpenIPMI-tools
+authconfig
+autoconf
+automake
+bash
+chkconfig
+compat-libstdc++-33.i686
+comps-extras
+coreutils
+curl
+dhclient
+dmidecode
+efibootmgr
+gcc
+gcc-c++
+git
+gzip
+kernel
+libstdc++.i686
+libsysfs.x86_64
+libxml2
+libxml2-devel
+libxml2.i686
+libxslt
+lvm2
+make
+mktemp
+ntp
+openssh-clients
+openssh-server
+openwsman-ruby
+parted
+passwd
+pciutils
+perl-XML-Twig
+policycoreutils
+rootfiles
+rpm
+ruby
+ruby-devel.x86_64
+ruby-libs.x86_64
+ruby-rdoc
+ruby-ri
+rubygems
+screen
+syslinux
+tar
+tcpdump
+unzip
+vim-enhanced
+wget
+which
+wsmancli
+yum
+zlib
+zlib-devel
+
+%post
+
+# Hack to really turn down SELINUX
+sed -i -e 's/\(^SELINUX=\).*$/\1disabled/' /etc/selinux/config
+
+########################################################################
+# Create a sub-script so the output can be captured
+# Must change "$" to "\$" and "`" to "\`" to avoid shell quoting
+########################################################################
+cat > /root/post-install << EOF_post
+#!/bin/bash
+
+echo ###################################################################
+echo ## Creating the centos-live init script
+echo ###################################################################
+
+cat > /etc/rc.d/init.d/openstack-start-up << EOF_initscript
+#!/bin/bash
+#
+# live: Init script for live image
+#
+# chkconfig: 345 72 28
+# description: Init script for live image.
+screen -d -m -S sledgehammer-bootstrap -t 'Sledgehammer Bootstrap' \
+    script -f -c '/sbin/sledgehammer-start-up.sh' /var/log/install.log
+
+
+EOF_initscript
+
+/sbin/chkconfig --add openstack-start-up
+
+EOF_post
+
+/bin/bash -x /root/post-install 2>&1 | tee /root/post-install.log
+
+
+%post --nochroot
+
+########################################################################
+# Create a sub-script so the output can be captured
+# Must change "$" to "\$" and "`" to "\`" to avoid shell quoting
+########################################################################
+cat > /root/postnochroot-install << EOF_postnochroot
+#!/bin/bash
+
+cp start-up.sh $INSTALL_ROOT/sbin/sledgehammer-start-up.sh
+chmod +x $INSTALL_ROOT/etc/rc.d/init.d/openstack-start-up
+chmod +x $INSTALL_ROOT/sbin/sledgehammer-start-up.sh
+cp sshd_config $INSTALL_ROOT/etc/ssh/sshd_config
+
+cp dhclient.conf $INSTALL_ROOT/etc
+
+EOF_postnochroot
+
+/bin/bash -x /root/postnochroot-install 2>&1 | tee /root/postnochroot-install.log
+
+%end


### PR DESCRIPTION
This pull request series allows the Crowbar build system to let the
provisioner handle building Sledgehammer instead of forcing the
top-level build machinery to have sole responsibility for building
it.  This makes it possible for releases to have their own versions of
Sledgehammer instead of forcing all releases to assume they are
talking to the same Sledgehammer image.

The first use of this functionality is also included in this pull
request, which changes how Sledgehammer operates for CB 2.0:
- Remove some unneeded bundled packages (Chef and friends,
  specifically)
- Remove our reliance on NFS.
- Change the default password for the root user on Sledgehammer to "crowbar"
  
  build.sh                                           |  14 +-
  build_sledgehammer.sh                              | 237 +++++++++++++++++++++
  build_sledgehammer_lib.sh                          |  88 ++++++++
  .../provisioner/recipes/setup_base_images.rb       |  54 ++---
  chef/cookbooks/provisioner/recipes/update_nodes.rb |  22 +-
  .../provisioner/templates/default/control.sh.erb   | 230 +-------------------
  crowbar.yml                                        |   2 +
  .../models/barclamp_provisioner/dhcp_database.rb   |   2 -
  sledgehammer-common/build.expect                   |  10 +
  sledgehammer-common/dhclient.conf                  |  12 ++
  sledgehammer-common/sshd_config                    |  14 ++
  sledgehammer-common/start-up.sh                    | 189 ++++++++++++++++
  sledgehammer.ks                                    | 131 ++++++++++++
  13 files changed, 729 insertions(+), 276 deletions(-)

Crowbar-Pull-ID: 1ec7113e8c740a01d2d6b4b05f18567143c353b1

Crowbar-Release: development
