### PR TITLE
Have CB2.0 record what disks are where and in use. [2/3]

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/control.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/control.sh.erb
@@ -67,27 +67,5 @@ curl -g --digest -u "$CROWBAR_KEY" \
     -d 'alive=true'
 
 # We are alive, and we should have a host entry created now.  Wait forever to do something.
+# The last line in this script must always be exit 0!!
 exit 0
-
-nuke_everything() {
-    # Make sure that the kernel knows about all the partitions
-    for bd in /sys/block/sd*; do
-        [[ -b /dev/${bd##*/} ]] || continue
-        partprobe "/dev/${bd##*/}"
-    done
-    # and then wipe them all out.
-    while read maj min blocks name; do
-        [[ -b /dev/$name && -w /dev/$name && $name != name ]] || continue
-        [[ $name = loop* ]] && continue
-        [[ $name = dm* ]] && continue
-        if (( blocks >= 2048)); then
-            dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=2048"
-            dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=2048" "seek=$(($blocks - 2048))"
-        else
-            dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=$blocks"
-        fi
-    done < <(tac /proc/partitions)
-
-    ## for good measure, nuke partition tables on disks (nothing should remain bootable)
-    for i in `ls /dev/sd?`; do  parted -m -s  $i mklabel bsd ; sleep 1 ; done
-}

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.ubuntu.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.ubuntu.sh.erb
@@ -30,10 +30,12 @@ if [[ -f /etc/crowbar.install.key ]]; then
 fi
 
 put_alive() {
-    curl -u "$CROWBAR_KEY" --digest -L -X PUT \
+    while ! curl -f -u "$CROWBAR_KEY" --digest -L -X PUT \
         -d "bootenv=local" \
         -d "alive=$1" \
-        "http://<%=@admin_ip%>:3000/api/v2/nodes/$HOSTNAME"
+        "http://<%=@admin_ip%>:3000/api/v2/nodes/$HOSTNAME" &>/dev/null; do
+        sleep 1
+    done
 }
 
 case $1 in

--- a/crowbar_engine/barclamp_provisioner/app/models/barclamp_provisioner/os_install.rb
+++ b/crowbar_engine/barclamp_provisioner/app/models/barclamp_provisioner/os_install.rb
@@ -23,18 +23,13 @@ class BarclampProvisioner::OsInstall < Role
     }
   end
 
-  def on_transition(nr)
+  def on_active(nr)
     node = nr.node
+    return if node.bootenv == "local" || node.admin
     target = nr.all_my_data["crowbar"]["target_os"] rescue nr.deployment_data["crowbar"]["target_os"]
-    # this could be expanded if needed but "local" can be used for any overrides including simulator & docker vms
-    # local means, skip sledgehammer and use the installed OS
-    return if ["local"].member? node.bootenv
-    Rails.logger.info("provisioner-install: Trying to install #{target} on #{node.name} (bootenv: #{node.bootenv})")
-
     node.bootenv = "#{target}-install"
     # for most jigs we want force the node to check back in.  Since the 
-    node.alive = false
-    node.save!
+    node.reboot
   end
 
 end

--- a/script/roles/provisioner-os-install/01-install-os.sh
+++ b/script/roles/provisioner-os-install/01-install-os.sh
@@ -2,7 +2,32 @@
 
 [[ -x /etc/init.d/crowbar_join.sh || -x /etc/init.d/crowbar ]] && exit 0
 
+exec 2>&1
 set -x
-nohup /bin/bash -c 'command sleep 60; exec reboot' >/tmp/nohup.out &
+# <Chancellor Palpatine> Wipe them out.  All of them.
+# Start with volume groups.
+vgscan --ignorelockingfailure -P
+while read vg; do
+    vgremove -f "$vg"
+done < <(vgs --noheadings -o vg_name)
+# Continue with physical volumes
+pvscan --ignorelockingfailure
+while read pv; do
+    pvremove -f -y "$pv"
+done < <(pvs --noheadings -o pv_name)
+# Now zap any partitions.
+while read maj min blocks name; do
+    [[ -b /dev/$name && -w /dev/$name && $name != name ]] || continue
+    [[ $name = loop* ]] && continue
+    [[ $name = dm* ]] && continue
+    # Do our best to also zap any MD format metadata lying around that we can see.
+    mdadm --zero-superblock --force "/dev/$name" || :
+    if (( blocks >= 2048)); then
+        dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=2048"
+        dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=2048" "seek=$(($blocks - 2048))"
+    else
+        dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=$blocks"
+    fi
+done < <(tac /proc/partitions)
 exit 0
 

--- a/sledgehammer.ks
+++ b/sledgehammer.ks
@@ -41,6 +41,7 @@ libxml2.i686
 libxslt
 lvm2
 make
+mdadm
 mktemp
 ntp
 openssh-clients


### PR DESCRIPTION
This pull request records what physical disks are present, how they
can be accessed, and our best guess about which one the OS will wind
up installing on.

It also includes some OS install fixes, and a Sledgehammer update that
helps sanitize another annoyingly persistent disk signature.

 .../provisioner/templates/default/control.sh.erb   | 24 +------------------
 .../templates/default/crowbar_join.ubuntu.sh.erb   |  6 +++--
 .../app/models/barclamp_provisioner/os_install.rb  | 11 +++------
 .../roles/provisioner-os-install/01-install-os.sh  | 27 +++++++++++++++++++++-
 sledgehammer.ks                                    |  1 +
 5 files changed, 35 insertions(+), 34 deletions(-)

Crowbar-Pull-ID: 1861e20532f90489ad0409075a754cdb913aeb53

Crowbar-Release: development
