### PR TITLE
disable apparmor for dhcp [1/1]

### DIFF
--- a/chef/cookbooks/dhcp/recipes/default.rb
+++ b/chef/cookbooks/dhcp/recipes/default.rb
@@ -21,6 +21,11 @@ when "ubuntu","debian"
   pkg = "dhcp3"
   package "dhcp3-server"
   owner = "dhcpd"
+  bash "disable apparmor for dhcpd" do
+    command "ln -s /etc/apparmor.d/usr.sbin.dhcpd /etc/apparmor.d/disable/usr.sbin.dhcpd"
+    notifies :restart, "service[dhcp3-server]"
+    not_if "dpkg -l apparmor && file /etc/apparmor.d/disable/usr.sbin.dhcpd"
+  end
 when "redhat","centos"
   pkg = "dhcp"
   package "dhcp"


### PR DESCRIPTION
docker requires apparmor.  There will be many more fixes to come.

 chef/cookbooks/dhcp/recipes/default.rb |   20 ++++++++++++++------
 1 file changed, 14 insertions(+), 6 deletions(-)

Crowbar-Pull-ID: 8be1f372b7f7092049fe0af2df7c6583a5b19b1b

Crowbar-Release: development
