### PR TITLE
Upgrade IPMI barclamp to work with crowbar 2 [4/4]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -116,6 +116,7 @@ roles:
       - provisioner-server-data
     requires:
       - provisioner-dhcp-server
+      - ipmi-configure
     flags:
       - implicit
       - destructive


### PR DESCRIPTION
Upgrade IPMI barclamp to work with crowbar 2, including creation and allocation
of bmc network addresses.

 crowbar.yml |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: 341450787feb53da3651f56f963e1f3cdbc5b98e

Crowbar-Release: development
