### PR TITLE
Try harder in skipping the MSFT compat rules

### DIFF
--- a/chef/cookbooks/provisioner/recipes/bootdisk.rb
+++ b/chef/cookbooks/provisioner/recipes/bootdisk.rb
@@ -64,7 +64,10 @@ ruby_block "Find the fallback boot device" do
         File.symlink?(f) && (File.readlink(f).split('/')[-1] == dev)
       end
       unless bootdisks.empty?
-        bootdisk = bootdisks.find{|b|b =~ /^scsi-[a-zA-Z]/} ||
+        # SLE11 SP3 generates so-called "MSFT compatibility links"
+        # that start with scsi-1. Skip those, as those are less
+        # reusable than the normal links.
+        bootdisk = bootdisks.find{|b|b =~ /^scsi-[^1]/} ||
           bootdisks.find{|b|b =~ /^scsi-/} ||
           bootdisks.find{|b|b =~ /^ata-/} ||
           bootdisks.find{|b|b =~ /^cciss-/} ||


### PR DESCRIPTION
The by-id/ MS compatibility hack links that were added
as a maintenance update (and thereby are available in
the discovery image) are not recognized by the SP3 install
media, hence missing during install, which breaks.

The previous regexp was not good enough, some harddrives
do not start their naming with a letter, but a number. In
this case it seems udev always prefixes it with "2", so
hopefully this regexp is good enough..

https://bugzilla.novell.com/show_bug.cgi?id=864857
(cherry picked from commit ca5485175e51bbf56cdfcde92e8da5ae350ff1ee)
