### PR TITLE
hyperv: handle license_key=nil

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -217,7 +217,7 @@ if not nodes.nil? and not nodes.empty?
             owner "root"
             group "root"
             source "unattended.xml.erb"
-            variables(:license_key => mnode[:license_key],
+            variables(:license_key => mnode[:license_key] || "",
                       :os_name => os,
                       :image_name => image_name,
                       :admin_ip => admin_ip,


### PR DESCRIPTION
This problem occurs when using bulk-edit to allocate a hyper-v node.
