### PR TITLE
Install rubygem-ruby-shadow during crowbar_join --setup for SUSE

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -166,7 +166,7 @@ EOF
             echo_verbose "Failed to do zypper refresh, wait and try again"
             sleep 10
         done
-        while ! log_to zypper zypper -n install rubygem-chef ; do
+        while ! log_to zypper zypper -n install rubygem-chef rubygem-ruby-shadow ; do
             echo_verbose "Failed to do zypper install, wait and try again"
             sleep 10
         done


### PR DESCRIPTION
This is needed when we want to change user passwords.

(cherry picked from commit ccb8ced693312d8d6942c866f77c92618617bffd)
