### PR TITLE
crowbar_register: Do not keep sledgehammer-specific configuration

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -287,6 +287,17 @@ post_state $HOSTNAME "installing"
 rm -f /etc/chef/client.pem
 
 
+# Revert bits from sledgehammer that should not persist
+# -----------------------------------------------------
+
+# Now setup the hostname with the short name; we couldn't do that earlier
+# because we do like in sledgehammer (which sets the hostname to the FQDN one)
+hostname "${HOSTNAME%%.*}"
+
+# Remove the resolution for hostname in /etc/hosts; this shouldn't be needed anymore
+sed -i -e "s/\(127\.0\.0\.1.*\)/127.0.0.1 localhost.localdomain localhost/" /etc/hosts
+
+
 # Steps from autoyast profile
 # ---------------------------
 echo "$CROWBAR_KEY" > /etc/crowbar.install.key


### PR DESCRIPTION
When we first run chef-client, we need the FQDN to be resolvable, which
means we need it in /etc/hosts. But that's not something we want to
keep.

We also do not want to have "hostname" return the FQDN name anymore
after we're setup.
