### PR TITLE
add missing -n to zypper

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -149,15 +149,15 @@ fi
 # ---------------
 
 <% @repos.keys.sort.each do |name| %>
-zypper ar "<%= @repos[name][:url] %>" "<%= name %>"
+zypper -n ar "<%= @repos[name][:url] %>" "<%= name %>"
 <% end %>
 
 # Cloud-PTF has an unknown key, and this is expected
-zypper --gpg-auto-import-keys refresh -r SLE-Cloud-PTF
+zypper -n --gpg-auto-import-keys refresh -r SLE-Cloud-PTF
 
 ZYPPER_REF_OPT=
 test $CROWBAR_AUTO_IMPORT_KEYS -eq 1 && ZYPPER_REF_OPT=--gpg-auto-import-keys
-zypper $ZYPPER_REF_OPT refresh
+zypper -n $ZYPPER_REF_OPT refresh
 
 
 # Install packages that are needed


### PR DESCRIPTION
crowbar_register is supposed to be non-interactive.
