### PR TITLE
Avoid uselessly long loop when waiting for hostname

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -85,7 +85,7 @@ wait_for_network() {
 
 wait_for_hostname() {
     # wait for hostname to become available
-    tries_left=120
+    tries_left=10
     while ! hostname -f > /dev/null; do
       HOSTNAME=$(hostname -f)
       exit_code=$?


### PR DESCRIPTION
- if we can't ping the admin node, no need to enter the loop anyway
- make the loop shorter
