### PR TITLE
Add optional crowbar-applied boolean attribute to schema

### DIFF
--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -82,6 +82,7 @@
   "deployment": {
     "provisioner": {
       "crowbar-revision": 0,
+      "crowbar-applied": false,
       "schema-revision": 1,
       "element_states": {
         "provisioner-bootdisk-finder": [ "hardware-installing" ],

--- a/chef/data_bags/crowbar/bc-template-provisioner.schema
+++ b/chef/data_bags/crowbar/bc-template-provisioner.schema
@@ -98,6 +98,7 @@
           "mapping": {
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
+            "crowbar-applied": { "type": "bool" },
             "crowbar-status": { "type": "str" },
             "crowbar-failed": { "type": "str" },
             "crowbar-queued": { "type": "bool" },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -28,7 +28,7 @@ crowbar:
   order: 10
   run_order: 1060
   chef_order: 1060
-  proposal_schema_version: 2
+  proposal_schema_version: 3
 
 debs:
   ubuntu-10.10:


### PR DESCRIPTION
We add a crowbar applied attribute to mark the proposal as applied after
the chef run. This allows the UI to show that the current form of the
proposal has been 'applied' successfully (i.e. chef-client completed the
run w/ success) and that the proposal was not modified after that.

Update the proposal_schema_revision, so we can add the attribute to
schema for ('3rd party') barclamps that currently do not have it.

Refs: crowbar/crowbar#2044 (which adds this attribute to barclamps which
lack it), crowbar/barclamp-crowbar#1068 (which marks the proposals as
applied) and https://bugzilla.novell.com/show_bug.cgi?id=877486
