### PR TITLE
Disable probing of network interfaces

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -92,6 +92,13 @@ template "/root/.ssh/authorized_keys" do
   variables(:keys => node["crowbar"]["ssh"]["access_keys"])
 end
 
+template "/etc/sudo.conf" do
+  source "sudo.conf.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+end
+
 # Also put authorized_keys in tftpboot path on the admin node so that discovered
 # nodes can use the same.
 if node.roles.include? "crowbar"

--- a/chef/cookbooks/provisioner/templates/default/sudo.conf.erb
+++ b/chef/cookbooks/provisioner/templates/default/sudo.conf.erb
@@ -1,0 +1,5 @@
+# Managed by Chef DO NOT EDIT
+#
+
+# See http://www.sudo.ws/pipermail/sudo-workers/2014-January/000835.html
+Set probe_interfaces false


### PR DESCRIPTION
provides a significant speedup on running sudo on a larger
neutron deployment.

see http://www.sudo.ws/pipermail/sudo-workers/2014-January/000835.html
