### PR TITLE
crowbar_join.suse: Use file as reboot indicator

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -217,10 +217,15 @@ EOF
 class RebootHandlerReset < Chef::Handler
   def report
     if defined?(node[:crowbar_wall][:wait_for_reboot]) and node[:crowbar_wall][:wait_for_reboot]== true
-      node[:crowbar_wall][:wait_for_reboot] = false
-      node[:crowbar_wall][:wait_for_reboot_requesttime] = 0
-      node.save
-      Chef::Log.debug("node[:crowbar_wall][:wait_for_reboot] reset done")
+      boottime =`echo $(($(date +%s) - $(cat /proc/uptime|cut -d " " -f 1|cut -d "." -f 1)))`.to_i
+      if boottime > node[:crowbar_wall][:wait_for_reboot_requesttime]
+        node[:crowbar_wall][:wait_for_reboot] = false
+        node[:crowbar_wall][:wait_for_reboot_requesttime] = 0
+        node.save
+        Chef::Log.debug("node[:crowbar_wall][:wait_for_reboot] reset done")
+      else
+        Chef::Log.debug("No reset of wait_for_reboot flag. boottime #{boottime} still <= reboot requesttime #{node[:crowbar_wall][:wait_for_reboot_requesttime]}.")
+      end
     end
   end
 end


### PR DESCRIPTION
Currently we set node[:crowbar_wall][:wait_for_reboot] in the report
handler and reset this value in the start handler. That doesn't work if
there' another chef-client run before the reboot happens.
Fixing this by adding a file (/var/crowbar/wait_for_reboot) with the
report handler. This file is only removed when crowbar_join is called
after a reboot.
In the barclamps, node[:crowbar_wall][:wait_for_reboot] should still be
used to check if a node requested a reboot.
