### PR TITLE
Fix alias being nil corner case

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -268,7 +268,12 @@ if node["platform"] == "suse" && !node.roles.include?("provisioner-server")
 end
 
 aliaz = begin
-  node["crowbar"]["display"]["alias"]
+  display_alias = node["crowbar"]["display"]["alias"]
+  if display_alias && !display_alias.empty?
+    display_alias
+  else
+    node["hostname"]
+  end
 rescue
   node["hostname"]
 end


### PR DESCRIPTION
When the node's crowbar/display/alias was nil, we'd get a gsub with nil
later in the template. Force a conversion into an empty string.
