### PR TITLE
fix bash/zsh prompt

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -298,22 +298,22 @@ end
 
       :zsh_prompt_from_template => proc {
         node["provisioner"]["shell_prompt"].to_s \
-          .gsub("USER", "\\e[0;31m%n\\e[0m") \
-          .gsub("CWD", "\\e[0;35m%~\\e[0m") \
+          .gsub("USER", "%{\\e[0;31m%}%n%{\\e[0m%}") \
+          .gsub("CWD", "%{\\e[0;35m%}%~%{\\e[0m%}") \
           .gsub("SUFFIX", "%#") \
-          .gsub("ALIAS", "\\e[0;35m#{aliaz}\\e[0m") \
-          .gsub("HOST", "\\e[0;35m#{node["hostname"]}\\e[0m") \
-          .gsub("FQDN", "\\e[0;35m#{node["fqdn"]}\\e[0m")
+          .gsub("ALIAS", "%{\\e[0;35m%}#{aliaz}%{\\e[0m%}") \
+          .gsub("HOST", "%{\\e[0;35m%}#{node["hostname"]}%{\\e[0m%}") \
+          .gsub("FQDN", "%{\\e[0;35m%}#{node["fqdn"]}%{\\e[0m%}")
       },
 
       :bash_prompt_from_template => proc {
         node["provisioner"]["shell_prompt"].to_s \
-          .gsub("USER", "\\e[01;31m\\u\\e[0m") \
-          .gsub("CWD", "\\e[01;31m\\w\\e[0m") \
+          .gsub("USER", "\\[\\e[01;31m\\]\\u\\[\\e[0m\\]") \
+          .gsub("CWD", "\\[\\e[01;31m\\]\\w\\[\\e[0m\\]") \
           .gsub("SUFFIX", "${prompt_suffix}") \
-          .gsub("ALIAS", "\\e[01;35m#{aliaz}\\e[0m") \
-          .gsub("HOST", "\\e[01;35m#{node["hostname"]}\\e[0m") \
-          .gsub("FQDN", "\\e[01;35m#{node["fqdn"]}\\e[0m")
+          .gsub("ALIAS", "\\[\\e[01;35m\\]#{aliaz}\\[\\e[0m\\]") \
+          .gsub("HOST", "\\[\\e[01;35m\\]#{node["hostname"]}\\[\\e[0m\\]") \
+          .gsub("FQDN", "\\[\\e[01;35m\\]#{node["fqdn"]}\\[\\e[0m\\]")
       }
     )
   end


### PR DESCRIPTION
without this change, it would count invisible escape chars
towards the length of the prompt and thus wrap too early
in ugly ways
