### PR TITLE
Bugfix: hostname: Host name lookup failure

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -248,6 +248,7 @@ if not nodes.nil? and not nodes.empty?
                       :boot_device => (mnode[:crowbar_wall][:boot_device] rescue nil),
                       :raid_type => (mnode[:crowbar_wall][:raid_type] || "single"),
                       :raid_disks => (mnode[:crowbar_wall][:raid_disks] || []),
+                      :node_ip => mnode[:crowbar][:network][:admin][:address],
                       :node_fqdn => mnode[:fqdn],
                       :node_hostname => mnode[:hostname],
                       :target_platform_version => target_platform_version,

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -206,6 +206,16 @@ sync
         </script>
     </chroot-scripts>
     <init-scripts config:type="list">
+      <!-- bugfix bnc#886238: https://bugzilla.novell.com/show_bug.cgi?id=886238 -->
+      <script>
+       <filename>autoyast_set_hostentries.sh</filename>
+       <source>
+        <![CDATA[
+        echo "<%= @node_ip %> <%= @node_fqdn %> <%= @node_hostname %>" >> /etc/hosts 
+        ]]>
+       </source>
+      </script>
+      <!-- /bugfix bnc#886238: https://bugzilla.novell.com/show_bug.cgi?id=886238 -->
       <script>
         <source>
 <![CDATA[


### PR DESCRIPTION
Bug: https://bugzilla.novell.com/show_bug.cgi?id=886238

Fixed the bug: If the /etc/resolv.conf is broken, "hostname -f" could not say
the hostname of the current host.

Resolution: Added a new entry in the /etc/hosts file. (IP, FQDN & Hostname)

(As discussed in https://github.com/crowbar/barclamp-provisioner/pull/339)
