### PR TITLE
Bugfix: hostname: Host name lookup failure

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -247,7 +247,9 @@ if not nodes.nil? and not nodes.empty?
                       :boot_device => (mnode[:crowbar_wall][:boot_device] rescue nil),
                       :raid_type => (mnode[:crowbar_wall][:raid_type] || "single"),
                       :raid_disks => (mnode[:crowbar_wall][:raid_disks] || []),
+                      :node_ip => mnode[:crowbar][:network][:admin][:address],
                       :node_name => mnode[:fqdn],
+                      :node_hostname => mnode[:hostname],
                       :crowbar_join => "#{os_url}/crowbar_join.sh")
           end
 

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -204,6 +204,18 @@ sync
         </source>
       </script>
     </init-scripts>
+    <!-- bugfix bnc#886238: https://bugzilla.novell.com/show_bug.cgi?id=886238 -->
+    <post-scripts config:type="list">
+     <script>
+      <filename>autoyast_set_hostentries.sh</filename>
+      <source>
+       <![CDATA[
+       echo "<%= @node_ip %> <%= @node_name %> <%= @node_hostname %>" >> /etc/hosts 
+       ]]>
+      </source>
+     </script>
+    </post-scripts>
+    <!-- /bugfix bnc#886238: https://bugzilla.novell.com/show_bug.cgi?id=886238 -->
   </scripts>
   <software>
     <packages config:type="list">


### PR DESCRIPTION
Bug: https://bugzilla.novell.com/show_bug.cgi?id=886238

Fixed the bug: If the /etc/resolv.conf is broken, "hostname -f" could not say
the hostname of the current host.

Resolution: Added a new entry in the /etc/hosts file. (IP, FQDN & Hostname)
