### PR TITLE
handle multiple NTP servers (bnc#895824)

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -130,21 +130,27 @@ sync_time() {
         return
     fi
 
-    tries_left=120
+    local tries_left=120
 
-    # Warning! Newer sntp releases use different options (e.g. the one
-    # on openSUSE 12.1
-    while ! sntp -P no -r $VALID_NTP_SERVERS; do
+<% if @target_platform_version.to_f < 12.0 %>
+    SNTP_OPTS="-P no -r"
+<% else %>
+    SNTP_OPTS="-s"
+<% end %>
+    while [[ $tries_left > 0 ]] ; do
+        for ntpserver in $VALID_NTP_SERVERS ; do
+            if sntp $SNTP_OPTS $ntpserver; then
+                break 2
+            fi
+        done
         tries_left=$(($tries_left-1))
-        if [ $tries_left -eq 0 ]; then
-            VALID_NTP_SERVERS=""
-            echo_verbose "Giving up on time synchronization; will skip further attempts..."
-            break
-        fi
-
         echo_verbose "Waiting for NTP server(s)"
         sleep 1
     done
+    if [ $tries_left -eq 0 ]; then
+        VALID_NTP_SERVERS=""
+        echo_verbose "Giving up on time synchronization; will skip further attempts..."
+    fi
 }
 
 do_setup() {


### PR DESCRIPTION
sntp seems to use only the first NTP server and ignore others
https://bugzilla.novell.com/show_bug.cgi?id=895824

cherry picked from commit 8d6711d259d21a923134b0e0f5a02176de3d72b9
     (stoney branch)
