### PR TITLE
crowbar_register: Fix handling of --interface with multiple nics

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -119,9 +119,9 @@ elif test "x$NIC_CANDIDATES" == "x"; then
     echo "Cannot find any good interface that would be on the admin network."
     echo "Did the node boot with DHCP on the admin network?"
     exit 1
-elif test $MULTIPLE_NICS -ne 0; then
+elif test $DEFINEDDEV_FOUND -ne 1 -a $MULTIPLE_NICS -ne 0; then
     echo "More than one potential interface can be used:"
-    echo "   $NIC_CANCIDATES"
+    echo "   $NIC_CANDIDATES"
     echo ""
     echo "Please define the one to use with the --interface option."
     exit 1


### PR DESCRIPTION
When multiple nics are on the admin network, overwriting which chone
to pick via --interface did not work, since it didn't check for
the defined one to be found prior to aborting.
