### PR TITLE
Force default encoding to UTF-8 on newer ruby releases

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -251,6 +251,11 @@ EOF
         'start_handlers << reboot_handler_reset # these fire at the start of a run'; do
         grep -q -e "^$line$" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
     done
+
+    # work around: https://tickets.opscode.com/browse/CHEF-3304
+    line='Encoding.default_external = Encoding::UTF_8 if RUBY_VERSION > "1.9"'
+    grep -q -e "^$line$" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
+
 }
 
 do_chef_client_after_setup() {


### PR DESCRIPTION
This is to avoid issues with UTF-8 characters in input files (as happing on
e.g. SLE12). See https://tickets.opscode.com/browse/CHEF-3304.
