### PR TITLE
Do not hardcode the requirement for the cstruct rubygem anymore

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -245,7 +245,6 @@ sync
       <package>biosdevname</package>
       <package>netcat</package>
       <package>ruby2.1-rubygem-chef</package>
-      <package>ruby2.1-rubygem-cstruct</package>
 <% if @target_platform_version == "11.3" -%>
       <package>suse-cloud-release</package>
 <% else -%>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -174,7 +174,7 @@ PACKAGES_INSTALL="$PACKAGES_INSTALL openssh"
 
 # From autoyast profile
 PATTERNS_INSTALL="$PATTERNS_INSTALL Minimal base"
-PACKAGES_INSTALL="$PACKAGES_INSTALL biosdevname netcat ruby2.1-rubygem-chef ruby2.1-rubygem-cstruct supportutils-plugin-susecloud"
+PACKAGES_INSTALL="$PACKAGES_INSTALL biosdevname netcat ruby2.1-rubygem-chef supportutils-plugin-susecloud"
 
 # From sleshammer
 PACKAGES_INSTALL="$PACKAGES_INSTALL ruby2.1-rubygem-chef ruby2.1-rubygem-rest-client ruby2.1-rubygem-cstruct ruby2.1-rubygem-libxml-ruby ruby2.1-rubygem-wsman ruby2.1-rubygem-xml-simple"


### PR DESCRIPTION
https://github.com/crowbar/barclamp-deployer/pull/226 should obsolete
this.