### PR TITLE
Add chef-client to X-Start-Before of crowbar_join init script

### DIFF
--- a/chef/cookbooks/provisioner/files/default/crowbar_join.init.suse
+++ b/chef/cookbooks/provisioner/files/default/crowbar_join.init.suse
@@ -5,6 +5,7 @@
 # Should-Start:      neutron-ovs-cleanup xend libvirtd
 # Required-Stop:     $syslog $network $remote_fs sshd
 # Should-Stop:       
+# X-Start-Before:    chef-client
 # Default-Start:     3 5
 # Default-Stop:      0 1 2 6
 # Short-Description: Synchronize with Crowbar administration server


### PR DESCRIPTION
We want to start crowbar_join before chef-client.