### PR TITLE
Stop crowbar_join before openvswitch and ovs-usurp-config-br-fixed

### DIFF
--- a/chef/cookbooks/provisioner/files/default/crowbar_join.init.suse
+++ b/chef/cookbooks/provisioner/files/default/crowbar_join.init.suse
@@ -4,7 +4,7 @@
 # Required-Start:    $syslog $network $remote_fs sshd
 # Should-Start:      neutron-ovs-cleanup xend libvirtd
 # Required-Stop:     $syslog $network $remote_fs sshd
-# Should-Stop:       
+# Should-Stop:       openvswitch-switch ovs-usurp-config-br-fixed ovs-usurp-config-br-public
 # X-Start-Before:    chef-client
 # Default-Start:     3 5
 # Default-Stop:      0 1 2 6


### PR DESCRIPTION
When stopping after these services, crowbar_join is not able to reach
the admin server to change the state of the node.