### PR TITLE
sledgehammer: Tiny fix to output

### DIFF
--- a/updates/control_lib.sh
+++ b/updates/control_lib.sh
@@ -177,6 +177,7 @@ wait_for_pxe() {
         fi
 
         if [ $wantedexit = $ret ] ; then
+            echo # \n after "echo -n"
             if [ -n "$state" ]; then
                 echo "pxe file now contains: $state"
             else
@@ -188,6 +189,7 @@ wait_for_pxe() {
             echo -n "."
             let count=count+1
             [ $count -gt 30 ] && {
+                echo # \n after "echo -n"
                 if [ -n "$state" ]; then
                     echo "Warning: pxe file still contains $state. giving up."
                 else


### PR DESCRIPTION
We were missing a newline character between "echo -n" and a new line
output by another echo.