### PR TITLE
crowbar_register: Do not run if connected through ssh with no screen

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -63,6 +63,12 @@ if [ $(id -u) -gt 0 ]; then
     exit 1
 fi
 
+if test -n "$SSH_CONNECTION" -a -z "$STY"; then
+    echo "Not running in screen. Please run $0 inside screen to avoid problems during network re-configuration."
+    echo ""
+    exit 1
+fi
+
 if test $CROWBAR_FORCE -ne 1; then
     echo    "Running this tool will alter the system for integration with SUSE Cloud."
     echo -n "Continue? [y/N]: "


### PR DESCRIPTION
There'll be a network reconfiguration that will kill the script...