### PR TITLE
Allow another architectures to be registered

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -153,6 +153,10 @@ if test "x$MD5_ADMIN" != "x$MD5_LOCAL"; then
 fi
 
 
+#we need to know an architecture we are running on
+ARCH=`uname -m`
+
+
 # Setup the repos
 # ---------------
 
@@ -184,7 +188,7 @@ PACKAGES_INSTALL="$PACKAGES_INSTALL openssh"
 
 # From autoyast profile
 PATTERNS_INSTALL="$PATTERNS_INSTALL Minimal base"
-PACKAGES_INSTALL="$PACKAGES_INSTALL biosdevname netcat ruby2.1-rubygem-chef supportutils-plugin-susecloud"
+PACKAGES_INSTALL="$PACKAGES_INSTALL netcat ruby2.1-rubygem-chef supportutils-plugin-susecloud"
 
 # From sleshammer
 PACKAGES_INSTALL="$PACKAGES_INSTALL ruby2.1-rubygem-chef ruby2.1-rubygem-rest-client ruby2.1-rubygem-cstruct"
@@ -192,6 +196,10 @@ PACKAGES_INSTALL="$PACKAGES_INSTALL ruby2.1-rubygem-chef ruby2.1-rubygem-rest-cl
 PACKAGES_INSTALL="$PACKAGES_INSTALL ruby2.1-rubygem-libxml-ruby ruby2.1-rubygem-wsman ruby2.1-rubygem-xml-simple"
 <% end -%>
 PACKAGES_INSTALL="$PACKAGES_INSTALL parted lvm2 ipmitool curl tack nfs-client rsyslog ntp tcpdump"
+
+case $ARCH in
+    x86_64) PACKAGES_INSTALL+=" biosdevname";;
+esac
 
 zypper --non-interactive install -t pattern $PATTERNS_INSTALL
 # Auto-agree with the license since it was already agreed on for the admin server


### PR DESCRIPTION
Currently crowbar_register assumes we're running on x86_64 only.
If we want to add other KVM capable architectures, it is simply not
possible.

Let's change it in a way that we separate architectures specific
packages in to arch dependent list and add arch suffix into a repo name.

Signed-off-by: Dinar Valeev <dvaleev@suse.com>