### PR TITLE
Configuration error. Should be 'root_password_hast', see bc-template-pro...

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -44,8 +44,8 @@
   <users config:type="list">
       <user>
          <username>root</username>
-<% if @rootpw_hash != "" %>
-         <user_password><%= @rootpw_hash %></user_password>
+<% if @root_password_hash != "" %>
+         <user_password><%= @root_password_hash %></user_password>
          <encrypted config:type="boolean">true</encrypted>
 <% end %>
          <forename/>


### PR DESCRIPTION
Here is a mismatch between the variable defined in the schema (root_password_hash) and in the autoyast file (rootpw) 