### PR TITLE
Don't directly start dhcp server

### DIFF
--- a/chef/cookbooks/dhcp/recipes/default.rb
+++ b/chef/cookbooks/dhcp/recipes/default.rb
@@ -164,6 +164,6 @@ service "dhcp3-server" do
     end
   end
   supports :restart => true, :status => true, :reload => true
-  action node[:provisioner][:enable_pxe] ? ["enable", "start"] : ["disable", "stop"]
+  action node[:provisioner][:enable_pxe] ? "enable" : ["disable", "stop"]
 end
 

--- a/chef/cookbooks/dhcp/templates/default/subnet.conf.erb
+++ b/chef/cookbooks/dhcp/templates/default/subnet.conf.erb
@@ -1,4 +1,5 @@
 # File managed by Crowbar
+<% if node[:provisioner][:enable_pxe] -%>
 
 subnet <%= @network["subnet"] %> netmask <%= @network["netmask"]%> {
 <% if @network["router"] -%>
@@ -18,3 +19,5 @@ subnet <%= @network["subnet"] %> netmask <%= @network["netmask"]%> {
    }
 <% end -%>
 }
+
+<% end -%>


### PR DESCRIPTION
The following error was introducted with 8f539ad0d83271c:

    FATAL: Mixlib::ShellOut::ShellCommandFailed:
    service[dhcp3-server] (dhcp::default line 154) had an error:
    Mixlib::ShellOut::ShellCommandFailed: Expe
    cted process to exit with [0], but received '1'
    ---- Begin output of /sbin/service dhcpd start ----
    STDOUT: Starting ISC DHCPv4 4.x Server
    please see /var/log/rc.dhcpd.log for details
    STDERR: ..failed
    ---- End output of /sbin/service dhcpd start ----
    Ran /sbin/service dhcpd start returned 1

Problem was that there was no subnet defined so the dhcp-server was
unable to start. The subnet file is now changed whenever "enable_pxe"
changes and this triggers a delayed "restart" notification for the
dhcp-server.