### PR TITLE
Fix 022_upgrade_autoyast_repos migration

### DIFF
--- a/chef/data_bags/crowbar/migrate/provisioner/022_upgrade_autoyast_repos.rb
+++ b/chef/data_bags/crowbar/migrate/provisioner/022_upgrade_autoyast_repos.rb
@@ -1,5 +1,7 @@
 def upgrade ta, td, a, d
-  if !a['suse']['autoyast']['repos'].nil? && !a['suse']['autoyast']['repos'].empty?
+  # The 'suse' hierarchy is optional in the proposal template so we need to
+  # check the whole tree here.
+  if a.fetch('suse', {}).fetch('autoyast',{})['repos']
     if %w(common suse-11.3 suse-12.0).select {|k|
         a['suse']['autoyast']['repos'].keys.include? k
     }.empty?
@@ -12,10 +14,11 @@ def upgrade ta, td, a, d
 end
 
 def downgrade ta, td, a, d
-  if !a['suse']['autoyast']['repos']['suse-11.3'].nil? && !a['suse']['autoyast']['repos']['suse-11.3'].empty?
-    a['suse']['autoyast']['repos']      = a['suse']['autoyast']['repos']['suse-11.3']
-  elsif !a['suse']['autoyast'].nil?
-    a['suse'].delete('autoyast')
+  # The 'suse' hierarchy is optional in the proposal template
+  if a['suse'].fetch('autoyast', {}).fetch('repos', {})['suse-11.3']
+    a['suse']['autoyast']['repos'] = a['suse']['autoyast']['repos']['suse-11.3']
+  else
+    a.delete('suse')
   end
   return a, d
 end


### PR DESCRIPTION
The "suse" hierarchy in the proposal is optional and might not exist when
installing the barclamp.