### PR TITLE
Make Windows/Hyper-V Admin-Password configurable

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -278,7 +278,7 @@ if not nodes.nil? and not nodes.empty?
                       :admin_ip => admin_ip,
                       :admin_name => node[:hostname],
                       :crowbar_key => crowbar_key,
-                      :admin_pass => "crowbar",
+                      :admin_pass => node[:provisioner][:admin_pass],
                       :domain_name => node[:dns].nil? ? node[:domain] : (node[:dns][:domain] || node[:domain]))
           end
 

--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -76,6 +76,7 @@
       "use_local_security": true,
       "use_serial_console": false,
       "serial_tty": "ttyS0,115200n8",
+      "admin_pass": "crowbar",
       "dhcp": {
         "lease-time": 60,
         "state_machine": {
@@ -103,7 +104,7 @@
     "provisioner": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 22,
+      "schema-revision": 23,
       "element_states": {
         "provisioner-bootdisk-finder": [ "hardware-installing" ],
         "provisioner-server": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-provisioner.schema
+++ b/chef/data_bags/crowbar/bc-template-provisioner.schema
@@ -76,6 +76,7 @@
             "use_local_security": { "type": "bool", "required": true },
             "use_serial_console": { "type": "bool", "required": true },
             "serial_tty": { "type": "str",  "required": true },
+            "admin_pass": { "type": "str",  "required": true },
             "dhcp": {
               "type": "map",
               "required": true,

--- a/chef/data_bags/crowbar/migrate/provisioner/023_add_hyperv-adminpassword.rb
+++ b/chef/data_bags/crowbar/migrate/provisioner/023_add_hyperv-adminpassword.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['admin_pass'] = ta['admin_pass']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('admin_pass')
+  return a, d
+end

--- a/crowbar_framework/app/views/barclamp/provisioner/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/provisioner/_edit_attributes.html.haml
@@ -11,6 +11,8 @@
     %span.help-block
       = t(".shell_prompt_hint")
 
+    = password_field :admin_pass
+
     %fieldset
       %legend
         = t(".serial_console")

--- a/crowbar_framework/config/locales/provisioner/en.yml
+++ b/crowbar_framework/config/locales/provisioner/en.yml
@@ -26,3 +26,4 @@ en:
         serial_console: 'Serial Console'
         use_serial_console: 'Enable Serial Console'
         serial_tty: 'Serial Console Device'
+        admin_pass: 'Administrator Password'


### PR DESCRIPTION
This change still needs some testing. **Do not merge yet!**
I open the PR for review and discussion:
- Should there be a helper text next to the password field that describes what characters are (not) allowed?
- Should the password be validated before it gets accepted?
- Is the number in the migration filename correct?

