### PR TITLE
Improve Windows/Hyper-V Admin-Password Feature

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -278,7 +278,7 @@ if not nodes.nil? and not nodes.empty?
                       :admin_ip => admin_ip,
                       :admin_name => node[:hostname],
                       :crowbar_key => crowbar_key,
-                      :admin_pass => node[:provisioner][:admin_pass],
+                      :admin_password => node[:provisioner][:windows][:admin_password],
                       :domain_name => node[:dns].nil? ? node[:domain] : (node[:dns][:domain] || node[:domain]))
           end
 

--- a/chef/cookbooks/provisioner/templates/default/unattended.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/unattended.xml.erb
@@ -136,11 +136,11 @@
                     <Order>13</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c schtasks.exe /Create /RU administrator /RP <%=@admin_pass%> /sc ONSTART /TN crowbar_join /TR "powershell -ExecutionPolicy RemoteSigned C:\Crowbar\crowbar_join.ps1"</CommandLine>
+                    <CommandLine>cmd /c schtasks.exe /Create /RU administrator /RP <%=@admin_password%> /sc ONSTART /TN crowbar_join /TR "powershell -ExecutionPolicy RemoteSigned C:\Crowbar\crowbar_join.ps1"</CommandLine>
                     <Order>14</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c schtasks.exe /Create /RU administrator /RP <%=@admin_pass%> /SC MINUTE /MO 12 /ST 00:00 /TN chef-client /TR "C:\opscode\chef\bin\chef-client.bat"</CommandLine>
+                    <CommandLine>cmd /c schtasks.exe /Create /RU administrator /RP <%=@admin_password%> /SC MINUTE /MO 12 /ST 00:00 /TN chef-client /TR "C:\opscode\chef\bin\chef-client.bat"</CommandLine>
                     <Order>15</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
@@ -154,13 +154,13 @@
             </FirstLogonCommands>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value><%=@admin_pass%></Value>
+                    <Value><%=@admin_password%></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
             </UserAccounts>
             <AutoLogon>
                 <Password>
-                    <Value><%=@admin_pass%></Value>
+                    <Value><%=@admin_password%></Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>

--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -76,7 +76,9 @@
       "use_local_security": true,
       "use_serial_console": false,
       "serial_tty": "ttyS0,115200n8",
-      "admin_pass": "crowbar",
+      "windows": {
+        "admin_password": "crowbar"
+      },
       "dhcp": {
         "lease-time": 60,
         "state_machine": {

--- a/chef/data_bags/crowbar/bc-template-provisioner.schema
+++ b/chef/data_bags/crowbar/bc-template-provisioner.schema
@@ -76,7 +76,13 @@
             "use_local_security": { "type": "bool", "required": true },
             "use_serial_console": { "type": "bool", "required": true },
             "serial_tty": { "type": "str",  "required": true },
-            "admin_pass": { "type": "str",  "required": true },
+            "windows": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "admin_password": { "type": "str",  "required": true }
+              }
+            },
             "dhcp": {
               "type": "map",
               "required": true,

--- a/chef/data_bags/crowbar/migrate/provisioner/023_add_hyperv-adminpassword.rb
+++ b/chef/data_bags/crowbar/migrate/provisioner/023_add_hyperv-adminpassword.rb
@@ -1,9 +1,9 @@
 def upgrade ta, td, a, d
-  a['admin_pass'] = ta['admin_pass']
+  a['windows'] = ta['windows']
   return a, d
 end
 
 def downgrade ta, td, a, d
-  a.delete('admin_pass')
+  a.delete('windows')
   return a, d
 end

--- a/crowbar_framework/app/views/barclamp/provisioner/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/provisioner/_edit_attributes.html.haml
@@ -11,7 +11,9 @@
     %span.help-block
       = t(".shell_prompt_hint")
 
-    = password_field :admin_pass
+    = password_field %w(windows admin_password)
+    %span.help-block
+      = t(".windows.admin_password_hint")
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/provisioner/en.yml
+++ b/crowbar_framework/config/locales/provisioner/en.yml
@@ -26,4 +26,6 @@ en:
         serial_console: 'Serial Console'
         use_serial_console: 'Enable Serial Console'
         serial_tty: 'Serial Console Device'
-        admin_pass: 'Administrator Password'
+        windows:
+          admin_password: 'Windows Administrator Password'
+          admin_password_hint: 'This password is only set on initial installation of Windows Server and Hyper-V Server, and any subsequent changes here will not be propagated to the nodes.'


### PR DESCRIPTION
This is a follow-up on #406.
As discussed there, the attribute gets renamed to `admin_password` and put into a mapping called `windows` to clarify it's function.
In the Crowbar UI a hint gets added to explain it's functionality.