### PR TITLE
give network time to be started (bnc#927997)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -218,6 +218,7 @@ if not nodes.nil? and not nodes.empty?
 
         when os =~ /^(open)?suse/
           append << "install=#{install_url} autoyast=#{node_url}/autoyast.xml"
+          append << "ifcfg=dhcp4 netwait=60"
 
           Provisioner::Repositories.inspect_repos(node)
           target_platform_version = os.gsub(/^.*-/, "")


### PR DESCRIPTION
In https://bugzilla.suse.com/show_bug.cgi?id=927997
we found that Dell Poweredge C6105 systems
do not transfer traffic for 30 seconds
after the interface comes up, which is why wicked timed out before

Also there is no point in letting it wait for DHCPv6 responses.

These additional params are only needed on SLE12+ but dont hurt on others either