### PR TITLE
crowbar_register: Fix error message for hostname test

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -261,7 +261,7 @@ else
     echo "The fully qualified domain name did not contain the $DOMAIN cloud domain."
     exit 1
   elif echo "${HOSTNAME%%.$DOMAIN}" | grep -q "\."; then
-    echo "The hostname is not a fully qualified domain name."
+    echo "The hostname is in a subdomain of the $DOMAIN cloud domain."
     exit 1
   fi
 fi


### PR DESCRIPTION
We check if there's a dot after removing the domain we expect; when
that's the case, then we're in a subdomain.