### PR TITLE
Make SUSE Cloud repos optional to allow Storage-only deployments

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -250,6 +250,8 @@ if not nodes.nil? and not nodes.empty?
                       :node_fqdn => mnode[:fqdn],
                       :node_hostname => mnode[:hostname],
                       :target_platform_version => target_platform_version,
+                      :is_ses => node[:provisioner][:suse] &&
+                        node[:provisioner][:suse][:missing_cloud] && !node[:provisioner][:suse][:missing_storage],
                       :crowbar_join => "#{os_url}/crowbar_join.sh")
           end
 

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -268,12 +268,16 @@ sync
       <package>biosdevname</package>
       <package>netcat</package>
       <package>ruby2.1-rubygem-chef</package>
-<% if @target_platform_version == "11.3" -%>
-      <package>suse-sle11-openstack-cloud-release</package>
+<% if @is_ses -%>
+      <package>ses-release</package>
 <% else -%>
+  <% if @target_platform_version == "11.3" -%>
+      <package>suse-sle11-openstack-cloud-release</package>
+  <% else -%>
       <package>suse-openstack-cloud-release</package>
-<% end -%>
+  <% end -%>
       <package>supportutils-plugin-susecloud</package>
+<% end -%>
     </packages>
     <patterns config:type="list">
       <pattern>Minimal</pattern>


### PR DESCRIPTION
This makes the SUSE Cloud repos optional, in the same way that SLE HA
and Storage repos are already optional, i.e. everything except the base
OS is now optional.

If the Storage repos are present but Cloud repos are not, the autoyast
profile is tweaked to perform a Storage-only deployment, by installing
ses-release instead of suse-sle12-cloud-compute-release.

Signed-off-by: Tim Serong <tserong@suse.com>