### PR TITLE
Deal with suse-openstack-cloud-sle11-release renaming

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -269,7 +269,7 @@ sync
       <package>netcat</package>
       <package>ruby2.1-rubygem-chef</package>
 <% if @target_platform_version == "11.3" -%>
-      <package>suse-openstack-cloud-sle11-release</package>
+      <package>suse-sle11-openstack-cloud-release</package>
 <% else -%>
       <package>suse-openstack-cloud-release</package>
 <% end -%>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -308,7 +308,7 @@ esac
 zypper --non-interactive install -t pattern $PATTERNS_INSTALL
 # Auto-agree with the license since it was already agreed on for the admin server
 <% if @target_platform_version.to_f < 12.0 -%>
-zypper --non-interactive install --auto-agree-with-licenses suse-openstack-cloud-sle11-release
+zypper --non-interactive install --auto-agree-with-licenses suse-sle11-openstack-cloud-release
 <% else -%>
 zypper --non-interactive install --auto-agree-with-licenses suse-openstack-cloud-release
 <% end -%>


### PR DESCRIPTION
It got renamed to suse-sle11-openstack-cloud-release.