### PR TITLE
Add missing stop command to crowbar_join.service

### DIFF
--- a/chef/cookbooks/provisioner/files/default/crowbar_join.service
+++ b/chef/cookbooks/provisioner/files/default/crowbar_join.service
@@ -7,6 +7,7 @@ Before=chef-client.service
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/sbin/crowbar_join --start
+ExecStop=/usr/sbin/crowbar_join --stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is important to have proper behavior on reboot/shutdown.