### PR TITLE
[tex] Add missing stop command to crowbar_join.service

### DIFF
--- a/chef/cookbooks/provisioner/files/default/crowbar_join.service
+++ b/chef/cookbooks/provisioner/files/default/crowbar_join.service
@@ -7,6 +7,7 @@ Before=chef-client.service
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/sbin/crowbar_join --start
+ExecStop=/usr/sbin/crowbar_join --stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Backport of https://github.com/crowbar/barclamp-provisioner/pull/418

This is important to have proper behavior on reboot/shutdown.

(cherry picked from commit 4ab7f12d6dd999f3704d45281ea20ac747a53a0f)