### PR TITLE
Fix Cloud repo names

### DIFF
--- a/chef/cookbooks/provisioner/libraries/repositories.rb
+++ b/chef/cookbooks/provisioner/libraries/repositories.rb
@@ -23,15 +23,15 @@ class Provisioner
           case version
           when "11.3"
             %w(
-              SLE-Cloud
-              SLE-Cloud-PTF
+              Cloud
+              Cloud-PTF
               SUSE-OpenStack-Cloud-SLE11-6-Pool
               SUSE-OpenStack-Cloud-SLE11-6-Updates
             )
           when "12.0"
             %w(
-              SLE-Cloud
-              SLE-Cloud-PTF
+              Cloud
+              Cloud-PTF
               SUSE-OpenStack-Cloud-6-Pool
               SUSE-OpenStack-Cloud-6-Updates
             )
@@ -92,9 +92,8 @@ class Provisioner
             suse_optional_repos(version, :cloud).each do |name|
               repos[name] ||= Mash.new
               next unless repos[name][:url].nil?
-              path_name = name.sub(/^SLE-Cloud/, 'Cloud')
-              missing_cloud ||= !(File.exists?("#{node[:provisioner][:root]}/suse-#{version}/repos/#{path_name}/repodata/repomd.xml") ||
-                                  File.exists?("#{node[:provisioner][:root]}/suse-#{version}/repos/#{path_name}/suse/repodata/repomd.xml"))
+              missing_cloud ||= !(File.exists?("#{node[:provisioner][:root]}/suse-#{version}/repos/#{name}/repodata/repomd.xml") ||
+                                  File.exists?("#{node[:provisioner][:root]}/suse-#{version}/repos/#{name}/suse/repodata/repomd.xml"))
             end
 
             # For pacemaker
@@ -175,8 +174,7 @@ class Provisioner
           # JSON due to the dynamic nature of the default value.
           repo_names.each do |name|
             repos[name] = repos_from_attrs.fetch(name, Mash.new)
-            suffix = name.sub(/^SLE-Cloud/, 'Cloud')
-            repos[name][:url] ||= default_repos_url + '/' + suffix
+            repos[name][:url] ||= default_repos_url + '/' + name
           end
 
           # optional repos

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -280,7 +280,7 @@ zypper -n ar "<%= @repos[name][:url] %>" "<%= name %>"
 <% end %>
 
 # Cloud-PTF has an unknown key, and this is expected
-zypper -n --gpg-auto-import-keys refresh -r SLE-Cloud-PTF
+zypper -n --gpg-auto-import-keys refresh -r Cloud-PTF
 
 ZYPPER_REF_OPT=
 test $CROWBAR_AUTO_IMPORT_KEYS -eq 1 && ZYPPER_REF_OPT=--gpg-auto-import-keys


### PR DESCRIPTION
The repos are named Cloud and Cloud-PTF without the SLE-. Let's use the
correct name instead of changin it on runtime. This is basicaly needed
because the gsub is missing on some other places.