### PR TITLE
Fix existence checks of packages lists for "Additional Packages" feature

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -303,8 +303,10 @@ if node["platform"] == "suse" && !node.roles.include?("provisioner-server")
     end
     # install additional packages
     os = "#{node[:platform]}-#{node[:platform_version]}"
-    if node[:provisioner][:packages][os]
-      node[:provisioner][:packages][os].each { |p| package p }
+    if node[:provisioner][:packages]
+      if node[:provisioner][:packages][os]
+        node[:provisioner][:packages][os].each { |p| package p }
+      end
     end
   end
 end

--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -424,7 +424,10 @@ node[:provisioner][:supported_oses].each do |os,params|
     Provisioner::Repositories.inspect_repos(node)
     repos = Provisioner::Repositories.get_repos(node, "suse", target_platform_version)
 
-    packages = node[:provisioner][:packages][os] || []
+    packages = []
+    if node[:provisioner][:packages]
+      packages = node[:provisioner][:packages][os] || []
+    end
 
     template "#{os_dir}/crowbar_register" do
       mode 0644

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -232,7 +232,10 @@ if not nodes.nil? and not nodes.empty?
             end
           end
 
-          packages = node[:provisioner][:packages][os] || []
+          packages = []
+          if node[:provisioner][:packages]
+            packages = node[:provisioner][:packages][os] || []
+          end
 
           template "#{node_cfg_dir}/autoyast.xml" do
             mode 0644


### PR DESCRIPTION
This is a follow-up pull request to #420 
Refactoring introduced a bug that slipped through my tests.

The way I checked the existence of additional packages entries at the end raised an `undefined method '[]' for nil:NilClass` as long `:packages` did not exist yet.