### PR TITLE
Fix "packages" attribute requirement

### DIFF
--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -73,6 +73,7 @@
       "timezone": "UTC",
       "web_port": 8091,
       "coredump": false,
+      "packages": {},
       "use_local_security": true,
       "use_serial_console": false,
       "serial_tty": "ttyS0,115200n8",

--- a/chef/data_bags/crowbar/bc-template-provisioner.schema
+++ b/chef/data_bags/crowbar/bc-template-provisioner.schema
@@ -75,7 +75,7 @@
             },
             "packages": {
               "type": "map",
-              "required": false,
+              "required": true,
               "mapping": {
                 =: {
                   "type": "seq",


### PR DESCRIPTION
This is a follow-up pull request to #420 and an alternative to #425.
Refactoring introduced a bug that slipped through my tests.

The `packages` attribute was not required in the schema and got only created in the migration but not in the initial JSON. So Crowbar installation failed.