### PR TITLE
Allow only legal characters in names of additional packages and put them in quotes

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -297,11 +297,6 @@ PACKAGES_INSTALL=
 # Obvious dependencies
 PACKAGES_INSTALL="$PACKAGES_INSTALL openssh"
 
-<% unless @packages.empty? -%>
-# Additional packages
-PACKAGES_INSTALL="$PACKAGES_INSTALL <%= @packages.join(' ') %>"
-<% end -%>
-
 # From autoyast profile
 PATTERNS_INSTALL="$PATTERNS_INSTALL Minimal base"
 PACKAGES_INSTALL="$PACKAGES_INSTALL netcat ruby2.1-rubygem-chef supportutils-plugin-susecloud"
@@ -317,7 +312,7 @@ zypper --non-interactive install --auto-agree-with-licenses suse-sle11-openstack
 <% else -%>
 zypper --non-interactive install --auto-agree-with-licenses suse-openstack-cloud-release
 <% end -%>
-zypper --non-interactive install $PACKAGES_INSTALL
+zypper --non-interactive install $PACKAGES_INSTALL<%= " '#{@packages.join("' '")}'" unless @packages.empty? %>
 
 # Fail early if we know we can't succeed because of a missing chef-client
 if ! which chef-client &> /dev/null; then

--- a/crowbar_framework/app/models/provisioner_service.rb
+++ b/crowbar_framework/app/models/provisioner_service.rb
@@ -51,6 +51,14 @@ class ProvisionerService < ServiceObject
   end
 
   def validate_proposal_after_save proposal
+    proposal["attributes"]["provisioner"]["packages"].each do |platform, packages|
+      packages.each do |package|
+        unless Crowbar::Validator::PackageNameValidator.new.validate(package)
+          validation_error("Package \"#{package}\" for \"#{platform}\" did not pass name validation.")
+        end
+      end
+    end
+
     validate_one_for_role proposal, "provisioner-server"
 
     super


### PR DESCRIPTION
I would like to improve string handling in the _additional packages_ feature.
Without that, it accepts any string as a package name.
This can be exploited with `crowbar_register` e.g. with `; rm foo; zypper in ` as a package name.

The first commit adds a validation RegEx that only allows characters from the [package naming guidelines](https://en.opensuse.org/openSUSE:Package_naming_guidelines#Common_Character_Set_for_Package_Naming) plus the version number operater chars (`< > =`).

The second commit concerns only `crowbar_register` and puts quotes around every package name there. Otherwise you couldn't use the version operator as you would redirect stdin or stdout. (e.g. `'emacs>4.0'`)