### PR TITLE
Opening port 445 for samba commands

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/unattended.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/unattended.xml.erb
@@ -151,6 +151,10 @@
                     <CommandLine>shutdown /r /t 0</CommandLine>
                     <Order>17</Order>
                 </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>netsh advfirewall firewall set rule name="File and Printer Sharing (SMB-In)" new enable=yes</CommandLine>
+                    <Order>18</Order>
+                </SynchronousCommand>
             </FirstLogonCommands>
             <UserAccounts>
                 <AdministratorPassword>


### PR DESCRIPTION
Modified the windows unattended file to open port 445 for samba commands
https://trello.com/c/ZnrdM70i/382-3-p10-make-reinstall-work-for-windows-nodes