### PR TITLE
Adapt to package name change of supportutils-plugin-susecloud

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -276,7 +276,7 @@ sync
   <% else -%>
       <package>suse-openstack-cloud-release</package>
   <% end -%>
-      <package>supportutils-plugin-susecloud</package>
+      <package>supportutils-plugin-suse-openstack-cloud</package>
 <% end -%>
 <% @packages.each do |package| -%>
       <package><%= package %></package>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -299,7 +299,7 @@ PACKAGES_INSTALL="$PACKAGES_INSTALL openssh"
 
 # From autoyast profile
 PATTERNS_INSTALL="$PATTERNS_INSTALL Minimal base"
-PACKAGES_INSTALL="$PACKAGES_INSTALL netcat ruby2.1-rubygem-chef supportutils-plugin-susecloud"
+PACKAGES_INSTALL="$PACKAGES_INSTALL netcat ruby2.1-rubygem-chef supportutils-plugin-suse-openstack-cloud"
 
 case $ARCH in
     x86_64) PACKAGES_INSTALL+=" biosdevname";;


### PR DESCRIPTION
`supportutils-plugin-susecloud` was renamed to `supportutils-plugin-suse-openstack-cloud`