### PR TITLE
export EDITOR variable

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -131,7 +131,7 @@ bash "Disable Strict Host Key checking" do
 end
 
 bash "Set EDITOR=vi environment variable" do
-  code "echo \"EDITOR=vi\" > /etc/profile.d/editor.sh"
+  code "echo \"export EDITOR=vi\" > /etc/profile.d/editor.sh"
   not_if "export | grep -q EDITOR="
 end
 


### PR DESCRIPTION
without this, the variable is only available in bash
but not in sub-processes such as
knife node edit $NODE
or
crowbar nova proposal edit default