### PR TITLE
Run tftpd as tftp user

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/tftp.erb
+++ b/chef/cookbooks/provisioner/templates/default/tftp.erb
@@ -11,5 +11,5 @@ service tftp
        flags                   = IPv6 IPv4
        user                    = root
        server                  = /usr/sbin/in.tftpd
-       server_args             = -m /etc/tftpd.conf -s <%=@tftproot%>
+       server_args             = -u tftp -m /etc/tftpd.conf -s <%=@tftproot%>
 }


### PR DESCRIPTION
This is the same as what is done when using the tftpd service file. This
also ensures that tftpd doesn't use the nobody user, who might not have
access to some resources.