### PR TITLE
Work around tftp packaging change on SLE12 that breaks Provisioner

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -240,6 +240,15 @@ when "redhat","centos"
   package "tftp-server"
 when "suse"
   package "tftp"
+
+  # work around change in bnc#813226 which breaks
+  # read permissions for nobody and wwwrun user
+  directory tftproot do
+    recursive true
+    mode 0755
+    owner "root"
+    group "root"
+  end
 end
 
 cookbook_file "/etc/tftpd.conf" do


### PR DESCRIPTION
A questionable change in the SLE12 tftp package enforces
a permissions on /srv/tfpboot that breaks crowbar and the apache
provisioner. This has been filed as
https://bugzilla.suse.com/show_bug.cgi?id=940608