### PR TITLE
Fix power off state for reboot/shutdown

### DIFF
--- a/chef/cookbooks/provisioner/files/default/crowbar_join.service
+++ b/chef/cookbooks/provisioner/files/default/crowbar_join.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Synchronize with Crowbar administration server
-After=network.target syslog.target remote-fs.target sshd.service neutron-ovs-cleanup.service xend.service libvirtd.service
+After=crowbar_notify_shutdown.service
 Before=chef-client.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/sbin/crowbar_join --start
-ExecStop=/usr/sbin/crowbar_join --stop
+ExecStartPost=/usr/bin/echo "crowbar_join --start done"
 
 [Install]
 WantedBy=multi-user.target

--- a/chef/cookbooks/provisioner/files/default/crowbar_notify_shutdown.service
+++ b/chef/cookbooks/provisioner/files/default/crowbar_notify_shutdown.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Synchronize with Crowbar administration server (shutdown/reboot notify)
+After=network.target syslog.target remote-fs.target sshd.service neutron-ovs-cleanup.service xend.service libvirtd.service
+Before=crowbar_join.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/bin/true
+ExecStop=/usr/sbin/crowbar_join --stop
+ExecStopPost=/usr/bin/echo "crowbar_join --stop done"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
When a node is rebooted while the systemd service crowbar_join.service
is still in state "activating", the job is just cancelled without executing
the "ExecStop" command. Creating a new service which is responsible to set
the power state via "crowbar_join --stop" during reboot/shutdown solves this
problem.