### PR TITLE
Do not add conf file entries for virtual interfaces (bsc#816746)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -22,6 +22,7 @@ admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").
 web_port = node[:provisioner][:web_port]
 provisioner_web = "http://#{admin_ip}:#{web_port}"
 dhcp_hosts_dir = node["provisioner"]["dhcp_hosts"]
+virtual_intfs = ["tap", "qbr", "qvo", "qvb", "brq", "ovs"]
 
 nodes = search(:node, "*:*")
 if not nodes.nil? and not nodes.empty?
@@ -40,6 +41,7 @@ if not nodes.nil? and not nodes.empty?
     mac_list = []
     unless mnode["network"].nil? || mnode["network"]["interfaces"].nil?
       mnode["network"]["interfaces"].each do |net, net_data|
+        next if virtual_intfs.include?(net.slice(0..2))
         net_data.each do |field, field_data|
           next if field != "addresses"
           field_data.each do |addr, addr_data|


### PR DESCRIPTION
Solves bug: bsc#816746.

Does not add .conf file in /etc/dhcp3/hosts.d/ for virtual interfaces. So no accumulation of conf files in crowbar node for each VM. Constant interfaces (like bridges, physical interfaces) will continue to hold .conf file in this path.

This is a backport from Cloud6 : https://github.com/crowbar/crowbar-core/pull/12
