### PR TITLE
Create '/boot' partition for installation (bsc#935283)

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -27,6 +27,15 @@
     </signature-handling>
     <storage/>
   </general>
+  <% if @target_platform_version.to_f < 12 -%>
+    <bootloader>
+      <global>
+        <activate>true</activate>
+        <boot_boot>true</boot_boot>
+        <boot_mbr>true</boot_mbr>
+      </global>
+    </bootloader>
+  <% end -%>
   <add-on>
     <add_on_products config:type="list">
     <% @repos.keys.sort.each do |name| %>
@@ -96,7 +105,52 @@
           <device>/dev/<%= @boot_device %></device>
         <% end %>
         <initialize config:type="boolean">true</initialize>
-        <partitions config:type="list"/>
+        <% if @target_platform_version.to_f < 12 -%>
+          <partitions config:type="list">
+            <partition>
+              <create config:type="boolean">true</create>
+              <filesystem config:type="symbol">ext3</filesystem>
+              <format config:type="boolean">true</format>
+              <mount>/boot</mount>
+              <size>auto</size>
+            </partition>
+            <partition>
+              <create config:type="boolean">true</create>
+              <filesystem config:type="symbol">swap</filesystem>
+              <format config:type="boolean">true</format>
+              <mount>swap</mount>
+              <size>auto</size>
+            </partition>
+            <partition>
+              <create config:type="boolean">true</create>
+              <format config:type="boolean">true</format>
+              <mount>/</mount>
+              <size>auto</size>
+            </partition>
+          </partitions>
+        <% else -%>
+          <disklabel>gpt</disklabel>
+          <partitions config:type="list">
+            <partition>
+              <create config:type="boolean">true</create>
+              <partition_id config:type="integer">263</partition_id>
+              <size>10M</size>
+            </partition>
+            <partition>
+              <create config:type="boolean">true</create>
+              <filesystem config:type="symbol">swap</filesystem>
+              <format config:type="boolean">true</format>
+              <mount>swap</mount>
+              <size>auto</size>
+            </partition>
+            <partition>
+              <create config:type="boolean">true</create>
+              <format config:type="boolean">true</format>
+              <mount>/</mount>
+              <size>auto</size>
+            </partition>
+          </partitions>
+        <% end -%>
         <type config:type="symbol">CT_DISK</type>
         <use>all</use>
       </drive>


### PR DESCRIPTION
SLE11 nodes have issues while booting/installation for harddisk size > 2
TB. Create a boot partition of type gpt with embeded mbr to allow using
bigger disks for non-raid type.
