### PR TITLE
[tex] bsc#980569 sntp changes

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -133,7 +133,7 @@ sync_time() {
     local tries_left=120
 
 <% if @target_platform_version.to_f < 12.0 %>
-    SNTP_OPTS="-P no -r"
+    SNTP_OPTS="-r"
 <% else %>
     SNTP_OPTS="-s"
 <% end %>

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -133,7 +133,7 @@ sync_time() {
     local tries_left=120
 
 <% if @target_platform_version.to_f < 12.0 %>
-    SNTP_OPTS="-r"
+    SNTP_OPTS="-S"
 <% else %>
     SNTP_OPTS="-s"
 <% end %>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -380,7 +380,7 @@ export DOMAIN
 export HOSTNAME
 
 <% if @target_platform_version.to_f < 12.0 -%>
-ntp="sntp -r $NTP_SERVERS"
+ntp="sntp -S $NTP_SERVERS"
 <% else -%>
 ntp="sntp -s $NTP_SERVERS"
 <% end -%>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -380,7 +380,7 @@ export DOMAIN
 export HOSTNAME
 
 <% if @target_platform_version.to_f < 12.0 -%>
-ntp="sntp -P no -r $NTP_SERVERS"
+ntp="sntp -r $NTP_SERVERS"
 <% else -%>
 ntp="sntp -s $NTP_SERVERS"
 <% end -%>

--- a/updates/control.sh
+++ b/updates/control.sh
@@ -99,7 +99,7 @@ export DHCP_STATE MYINDEX ADMIN_ADDRESS BMC_ADDRESS BMC_NETMASK BMC_ROUTER ADMIN
 export ALLOCATED HOSTNAME CROWBAR_KEY CROWBAR_STATE
 
 if is_suse; then
-    ntp="sntp -P no -r $ADMIN_IP"
+    ntp="sntp -r $ADMIN_IP"
 else
     ntp="/usr/sbin/ntpdate $ADMIN_IP"
 fi

--- a/updates/control.sh
+++ b/updates/control.sh
@@ -99,7 +99,7 @@ export DHCP_STATE MYINDEX ADMIN_ADDRESS BMC_ADDRESS BMC_NETMASK BMC_ROUTER ADMIN
 export ALLOCATED HOSTNAME CROWBAR_KEY CROWBAR_STATE
 
 if is_suse; then
-    ntp="sntp -r $ADMIN_IP"
+    ntp="sntp -S $ADMIN_IP"
 else
     ntp="/usr/sbin/ntpdate $ADMIN_IP"
 fi


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=980569
It seems that there has been some changes in a recently released sntp

the `-P` option has been dropped, and `-r` is now `-S`

for further reading refer to the commit messages

this is currently an issue in the cloud 5 ci jobs:

![sntp](https://cloud.githubusercontent.com/assets/5364817/15384887/1e88d0f8-1d9e-11e6-89bf-51c8c41145be.png)
