### PR TITLE
Use ntpdate on systems with newer ntpd (bsc#980569)

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -132,14 +132,19 @@ sync_time() {
 
     local tries_left=120
 
-<% if @target_platform_version.to_f < 12.0 %>
-    SNTP_OPTS="-P no -r"
-<% else %>
-    SNTP_OPTS="-s"
-<% end %>
+    # ntpd 4.2.4 (e.g. on SLES11-SP3 GA) didn't contain a working ntpdate. Use sntp
+    # there. ntpdate got reintroduced with a newer ntpd versions (4.2.8x) where the
+    # sntp commandline interface changed in an incompatible way. Use ntpdate on
+    # such systems (i.e. SLES-11-SP3 with updates and SLES12)
+    if ntpd --version | grep -q "4\.2\.4"; then
+        ntp="sntp -P no -r"
+    else
+        ntp="/usr/sbin/ntpdate -u"
+    fi
+
     while [[ $tries_left > 0 ]] ; do
         for ntpserver in $VALID_NTP_SERVERS ; do
-            if sntp $SNTP_OPTS $ntpserver; then
+            if $ntp $ntpserver; then
                 break 2
             fi
         done

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -379,11 +379,16 @@ hostname "$HOSTNAME"
 export DOMAIN
 export HOSTNAME
 
-<% if @target_platform_version.to_f < 12.0 -%>
-ntp="sntp -P no -r $NTP_SERVERS"
-<% else -%>
-ntp="sntp -s $NTP_SERVERS"
-<% end -%>
+# ntpd 4.2.4 (e.g. on SLES11-SP3 GA) didn't contain a working ntpdate. Use sntp
+# there. ntpdate got reintroduced with a newer ntpd versions (4.2.8x) where the
+# sntp commandline interface changed in an incompatible way. Use ntpdate on
+# such systems (i.e. SLES-11-SP3 with updates and SLES12)
+if ntpd --version | grep -q "4\.2\.4"; then
+    ntp="sntp -P no -r $NTP_SERVERS"
+else
+    ntp="/usr/sbin/ntpdate -u $NTP_SERVERS"
+fi
+
 # Make sure date is up-to-date
 until $ntp; do
   echo "Waiting for NTP server(s)"

--- a/updates/control.sh
+++ b/updates/control.sh
@@ -98,10 +98,14 @@ ALLOCATED=false
 export DHCP_STATE MYINDEX ADMIN_ADDRESS BMC_ADDRESS BMC_NETMASK BMC_ROUTER ADMIN_IP
 export ALLOCATED HOSTNAME CROWBAR_KEY CROWBAR_STATE
 
-if is_suse; then
+# ntpd 4.2.4 (e.g. on SLES11-SP3 GA) didn't contain a working ntpdate. Use sntp
+# there. ntpdate got reintroduced with a newer ntpd versions (4.2.8x) where the
+# sntp commandline interface changed in an incompatible way. Use ntpdate on
+# such systems (i.e. SLES-11-SP3 with updates and SLES12)
+if ntpd --version | grep -q "4\.2\.4"; then
     ntp="sntp -P no -r $ADMIN_IP"
 else
-    ntp="/usr/sbin/ntpdate $ADMIN_IP"
+    ntp="/usr/sbin/ntpdate -u $ADMIN_IP"
 fi
 
 # Make sure date is up-to-date


### PR DESCRIPTION
With a recent update to ntpd-4.2.8p6 the commandline options of sntp changed in
a backwards incompatible way. Try to find out with version of ntp we're running
and uses sntp for older releases (4.2.4 didn't contain a working ntpdate) and
ntpdate for newer releases to do the initial time sync.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=980569
